### PR TITLE
feat: support --output-format json to return token usage metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Shared async Python package for calling AI CLI tools (Claude, Gemini, Cursor) vi
 import asyncio
 from pathlib import Path
 
-from ai_cli_runner import call_ai_cli, check_ai_cli_available, run_parallel_with_limit
+from ai_cli_runner import call_ai_cli, check_ai_cli_available, run_parallel_with_limit, AIResult, AITokenUsage
 
 
 async def main() -> None:
@@ -63,6 +63,80 @@ async def main() -> None:
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+## JSON Output / Token Usage
+
+Pass `output_format="json"` to get structured token usage metadata from providers that support it. Parsing is best-effort — if the provider output can't be parsed, usage fields fall back to defaults.
+
+```python
+result = await call_ai_cli(
+    prompt="Analyze this code",
+    cwd=Path("/path/to/repo"),
+    ai_provider="claude",
+    ai_model="claude-sonnet-4-6",
+    output_format="json",
+)
+
+# Structured result
+print(result.success)              # True
+print(result.text)                 # "Analysis text..."
+print(result.usage.input_tokens)   # 1234
+print(result.usage.output_tokens)  # 567
+print(result.usage.cost_usd)       # 0.05
+print(result.usage.duration_ms)    # 3000
+print(result.usage.model)          # "claude-sonnet-4-6"
+```
+
+`AIResult` supports tuple unpacking and boolean evaluation for backward compatibility:
+
+```python
+# Tuple unpacking still works
+success, text = await call_ai_cli(
+    prompt="Hello",
+    ai_provider="claude",
+    ai_model="claude-sonnet-4-6",
+)
+
+# Boolean evaluation reflects success
+result = await call_ai_cli(...)
+if result:
+    print(result.text)
+```
+
+### `AIResult`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `bool` | Whether the CLI call succeeded |
+| `text` | `str` | Output text from the AI |
+| `usage` | `AITokenUsage \| None` | Token usage metadata (when `output_format="json"`) |
+
+### `AITokenUsage`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `input_tokens` | `int` | `0` | Tokens in the prompt |
+| `output_tokens` | `int` | `0` | Tokens in the response |
+| `cache_read_tokens` | `int` | `0` | Tokens read from cache |
+| `cache_write_tokens` | `int` | `0` | Tokens written to cache |
+| `cost_usd` | `float \| None` | `None` | Estimated cost in USD |
+| `duration_ms` | `int \| None` | `None` | Wall-clock duration in ms |
+| `model` | `str` | `""` | Model used |
+| `provider` | `str` | `""` | Provider name |
+
+### Provider Support Matrix
+
+Not all providers return the same metadata. Fields that a provider does not report will be `None` or `0`.
+
+| Field | Claude | Gemini | Cursor |
+|-------|--------|--------|--------|
+| `input_tokens` | ✅ | ✅ | ✅ |
+| `output_tokens` | ✅ | ✅ | ✅ |
+| `cache_read_tokens` | ✅ | ✅ | ✅ |
+| `cache_write_tokens` | ✅ | ❌ | ✅ |
+| `cost_usd` | ✅ | ❌ | ❌ |
+| `duration_ms` | ✅ | ✅ | ✅ |
+| `model` | ✅ | ✅ | ❌ |
 
 ## Supported Providers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,10 @@ warn_redundant_casts = true
 [[tool.mypy.overrides]]
 module = "simple_logger.*"
 ignore_missing_imports = true
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "ruff>=0.15.11",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,6 @@ dependencies = [
     "python-simple-logger",
 ]
 
-[project.optional-dependencies]
-dev = ["mypy", "pytest", "pytest-asyncio", "pytest-xdist"]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -41,7 +38,9 @@ ignore_missing_imports = true
 
 [dependency-groups]
 dev = [
+    "mypy",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
+    "pytest-xdist",
     "ruff>=0.15.11",
 ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,11 +2,10 @@ line-length = 120
 target-version = "py312"
 
 [lint]
-select = ["E", "F", "W", "I", "UP", "S", "B", "A", "C4", "SIM", "TCH", "RUF"]
+select = ["E", "F", "W", "I", "UP", "S", "B", "A", "BLE", "C4", "SIM", "TCH", "RUF"]
 # S603: subprocess call with shell=False — expected, this package wraps subprocess calls
 # S607: partial executable path — expected, CLI tool names are resolved via PATH
 ignore = ["S603", "S607"]
 
 [lint.per-file-ignores]
 "tests/**" = ["S101"]
-"src/ai_cli_runner/client.py" = ["S101"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -9,3 +9,4 @@ ignore = ["S603", "S607"]
 
 [lint.per-file-ignores]
 "tests/**" = ["S101"]
+"src/ai_cli_runner/client.py" = ["S101"]

--- a/src/ai_cli_runner/__init__.py
+++ b/src/ai_cli_runner/__init__.py
@@ -1,13 +1,18 @@
 from ai_cli_runner.client import call_ai_cli, check_ai_cli_available, get_ai_cli_timeout
+from ai_cli_runner.models import AIResult, AITokenUsage
 from ai_cli_runner.parallel import run_parallel_with_limit
+from ai_cli_runner.parsers import parse_json_output
 from ai_cli_runner.providers import PROVIDERS, VALID_AI_PROVIDERS, ProviderConfig
 
 __all__ = [
     "PROVIDERS",
     "VALID_AI_PROVIDERS",
+    "AIResult",
+    "AITokenUsage",
     "ProviderConfig",
     "call_ai_cli",
     "check_ai_cli_available",
     "get_ai_cli_timeout",
+    "parse_json_output",
     "run_parallel_with_limit",
 ]

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from simple_logger.logger import get_logger
 
+from ai_cli_runner.models import AIResult
+from ai_cli_runner.parsers import parse_json_output
 from ai_cli_runner.providers import PROVIDERS, VALID_AI_PROVIDERS, ProviderConfig
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
@@ -140,7 +142,8 @@ async def call_ai_cli(
     ai_model: str = "",
     ai_cli_timeout: int | None = None,
     cli_flags: list[str] | None = None,
-) -> tuple[bool, str]:
+    output_format: str | None = None,
+) -> AIResult:
     """Call AI CLI (Claude, Gemini, or Cursor) with given prompt.
 
     Args:
@@ -150,27 +153,33 @@ async def call_ai_cli(
         ai_model: AI model to use.
         ai_cli_timeout: Timeout in minutes (overrides AI_CLI_TIMEOUT env var).
         cli_flags: Extra CLI flags to pass to the provider command.
+        output_format: Output format (e.g., "json"). When set, parses structured output.
 
     Returns:
-        Tuple of (success, output). success is True with AI output, False with error message.
+        AIResult with success status, text output, and optional usage metadata.
+        Supports tuple unpacking: success, text = await call_ai_cli(...)
     """
     valid, error_msg, config = _validate_provider_and_model(ai_provider, ai_model)
     if not valid:
-        return False, error_msg
+        return AIResult(success=False, text=error_msg)
 
-    # config is guaranteed non-None when valid=True
-    if config is None:  # pragma: no cover
-        return False, "Internal error: provider config is unexpectedly None"
+    assert config is not None  # guaranteed by _validate_provider_and_model
 
     provider_info = f"{ai_provider.upper()} ({ai_model})"
-    cmd = config.build_cmd(config.binary, ai_model, cwd, cli_flags or [])
 
-    subprocess_cwd = cwd
+    effective_cli_flags = list(cli_flags or [])
+    if output_format:
+        effective_cli_flags = ["--output-format", output_format, *effective_cli_flags]
+
+    cmd = config.build_cmd(config.binary, ai_model, cwd, effective_cli_flags)
 
     if ai_cli_timeout is None:
         effective_timeout = get_ai_cli_timeout()
     elif ai_cli_timeout <= 0:
-        return False, f"Invalid ai_cli_timeout: {ai_cli_timeout}. Must be a positive integer (minutes)."
+        return AIResult(
+            success=False,
+            text=f"Invalid ai_cli_timeout: {ai_cli_timeout}. Must be a positive integer (minutes).",
+        )
     else:
         effective_timeout = ai_cli_timeout
     timeout = effective_timeout * 60  # Convert minutes to seconds
@@ -181,34 +190,39 @@ async def call_ai_cli(
         result = await asyncio.to_thread(
             _run_with_process_group,
             cmd,
-            cwd=subprocess_cwd,
+            cwd=cwd,
             timeout=timeout,
             input_data=prompt,
         )
     except subprocess.TimeoutExpired:
-        return (
-            False,
-            f"{provider_info} CLI error: Analysis timed out after {effective_timeout} minutes",
+        return AIResult(
+            success=False,
+            text=f"{provider_info} CLI error: Analysis timed out after {effective_timeout} minutes",
         )
     except FileNotFoundError:
-        return (
-            False,
-            f"{provider_info} CLI error: '{config.binary}' not found. Ensure the CLI is installed and on PATH.",
+        return AIResult(
+            success=False,
+            text=f"{provider_info} CLI error: '{config.binary}' not found. Ensure the CLI is installed and on PATH.",
         )
 
     if result.returncode != 0:
         error_detail = result.stderr or result.stdout or "unknown error (no output)"
-        return False, f"{provider_info} CLI error: {error_detail}"
+        return AIResult(success=False, text=f"{provider_info} CLI error: {error_detail}")
 
     logger.debug("%s CLI response length: %d chars", provider_info, len(result.stdout))
-    return True, result.stdout
+
+    if output_format:
+        text, usage = parse_json_output(result.stdout, ai_provider)
+        return AIResult(success=True, text=text, usage=usage)
+
+    return AIResult(success=True, text=result.stdout)
 
 
 async def check_ai_cli_available(
     ai_provider: str = "",
     ai_model: str = "",
     cli_flags: list[str] | None = None,
-) -> tuple[bool, str]:
+) -> AIResult:
     """Check if an AI CLI tool is available and working.
 
     Sends a trivial "Hi" prompt to verify the CLI is installed and working.
@@ -219,15 +233,14 @@ async def check_ai_cli_available(
         cli_flags: Extra CLI flags to pass to the provider command.
 
     Returns:
-        Tuple of (available, message). available is True if working, False with error message.
+        AIResult with success=True if working, success=False with error message.
+        Supports tuple unpacking: available, msg = await check_ai_cli_available(...)
     """
     valid, error_msg, config = _validate_provider_and_model(ai_provider, ai_model)
     if not valid:
-        return False, error_msg
+        return AIResult(success=False, text=error_msg)
 
-    # config is guaranteed non-None when valid=True
-    if config is None:  # pragma: no cover
-        return False, "Internal error: provider config is unexpectedly None"
+    assert config is not None  # guaranteed by _validate_provider_and_model
 
     provider_info = f"{ai_provider.upper()} ({ai_model})"
     sanity_cmd = config.build_cmd(config.binary, ai_model, None, cli_flags or [])
@@ -242,10 +255,10 @@ async def check_ai_cli_available(
         )
         if sanity_result.returncode != 0:
             error_detail = sanity_result.stderr or sanity_result.stdout or "unknown"
-            return False, f"{provider_info} sanity check failed: {error_detail}"
+            return AIResult(success=False, text=f"{provider_info} sanity check failed: {error_detail}")
     except subprocess.TimeoutExpired:
-        return False, f"{provider_info} sanity check timed out"
+        return AIResult(success=False, text=f"{provider_info} sanity check timed out")
     except FileNotFoundError:
-        return False, f"{provider_info}: '{config.binary}' not found in PATH"
+        return AIResult(success=False, text=f"{provider_info}: '{config.binary}' not found in PATH")
 
-    return True, ""
+    return AIResult(success=True, text="")

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -4,6 +4,7 @@ import os
 import signal
 import subprocess
 from pathlib import Path
+from typing import Literal
 
 from simple_logger.logger import get_logger
 
@@ -142,7 +143,7 @@ async def call_ai_cli(
     ai_model: str = "",
     ai_cli_timeout: int | None = None,
     cli_flags: list[str] | None = None,
-    output_format: str | None = None,
+    output_format: Literal["json"] | None = None,
 ) -> AIResult:
     """Call AI CLI (Claude, Gemini, or Cursor) with given prompt.
 
@@ -153,7 +154,7 @@ async def call_ai_cli(
         ai_model: AI model to use.
         ai_cli_timeout: Timeout in minutes (overrides AI_CLI_TIMEOUT env var).
         cli_flags: Extra CLI flags to pass to the provider command.
-        output_format: Output format (e.g., "json"). When set, parses structured output.
+        output_format: Output format ("json" or None). When set, parses structured output.
 
     Returns:
         AIResult with success status, text output, and optional usage metadata.
@@ -163,13 +164,37 @@ async def call_ai_cli(
     if not valid:
         return AIResult(success=False, text=error_msg)
 
-    assert config is not None  # guaranteed by _validate_provider_and_model
+    if config is None:  # defensive: guaranteed by _validate_provider_and_model
+        raise RuntimeError("ProviderConfig unexpectedly None after validation")
 
     provider_info = f"{ai_provider.upper()} ({ai_model})"
 
     effective_cli_flags = list(cli_flags or [])
     if output_format:
-        effective_cli_flags = ["--output-format", output_format, *effective_cli_flags]
+        # Remove any existing --output-format flag (both "--output-format value" and "--output-format=value" forms)
+        cleaned_flags: list[str] = []
+        skip_next = False
+        found_existing = False
+        for i, flag in enumerate(effective_cli_flags):
+            if skip_next:
+                skip_next = False
+                continue
+            if flag == "--output-format":
+                found_existing = True
+                # Skip the next element (the value), if present
+                if i + 1 < len(effective_cli_flags):
+                    skip_next = True
+                continue
+            if flag.startswith("--output-format="):
+                found_existing = True
+                continue
+            cleaned_flags.append(flag)
+        if found_existing:
+            logger.warning(
+                "Caller-supplied --output-format in cli_flags will be overridden by output_format=%r",
+                output_format,
+            )
+        effective_cli_flags = ["--output-format", output_format, *cleaned_flags]
 
     cmd = config.build_cmd(config.binary, ai_model, cwd, effective_cli_flags)
 
@@ -213,6 +238,13 @@ async def call_ai_cli(
 
     if output_format:
         text, usage = parse_json_output(result.stdout, ai_provider)
+        if usage is None:
+            logger.debug(
+                "%s: output_format=%r requested but no usage parsed; raw output length=%d",
+                provider_info,
+                output_format,
+                len(result.stdout),
+            )
         return AIResult(success=True, text=text, usage=usage)
 
     return AIResult(success=True, text=result.stdout)
@@ -240,7 +272,8 @@ async def check_ai_cli_available(
     if not valid:
         return AIResult(success=False, text=error_msg)
 
-    assert config is not None  # guaranteed by _validate_provider_and_model
+    if config is None:  # defensive: guaranteed by _validate_provider_and_model
+        raise RuntimeError("ProviderConfig unexpectedly None after validation")
 
     provider_info = f"{ai_provider.upper()} ({ai_model})"
     sanity_cmd = config.build_cmd(config.binary, ai_model, None, cli_flags or [])

--- a/src/ai_cli_runner/models.py
+++ b/src/ai_cli_runner/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@dataclass
+class AITokenUsage:
+    """Token usage metadata from an AI CLI call."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    cost_usd: float | None = None
+    duration_ms: int | None = None
+    model: str = ""
+    provider: str = ""
+
+
+@dataclass
+class AIResult:
+    """Result from an AI CLI call.
+
+    Supports tuple unpacking for backward compatibility:
+        success, text = await call_ai_cli(...)
+    """
+
+    success: bool
+    text: str
+    usage: AITokenUsage | None = None
+
+    def __iter__(self) -> Iterator[Any]:
+        """Support tuple unpacking for backward compatibility.
+
+        Allows: success, text = await call_ai_cli(...)
+        """
+        return iter((self.success, self.text))
+
+    def __getitem__(self, index: int) -> Any:
+        """Support index access for backward compatibility."""
+        return (self.success, self.text)[index]
+
+    def __len__(self) -> int:
+        """Support len() for backward compatibility with tuple."""
+        return 2
+
+    def __bool__(self) -> bool:
+        """Return success status for boolean evaluation.
+
+        Allows: if result: ...
+        """
+        return self.success

--- a/src/ai_cli_runner/parsers.py
+++ b/src/ai_cli_runner/parsers.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from simple_logger.logger import get_logger
+
+from ai_cli_runner.models import AITokenUsage
+
+logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
+
+
+def _extract_json(raw_output: str) -> dict[str, Any]:
+    """Extract JSON from raw CLI output, handling noise lines (e.g., Gemini warnings).
+
+    First tries to parse the whole string. If that fails, finds the first '{'
+    and last '}' to extract the JSON block, handling both prefix and suffix noise.
+
+    Raises:
+        json.JSONDecodeError: If no valid JSON found.
+    """
+    try:
+        return json.loads(raw_output)
+    except json.JSONDecodeError:
+        start = raw_output.find("{")
+        end = raw_output.rfind("}")
+        if start == -1 or end == -1 or end < start:
+            raise
+        return json.loads(raw_output[start : end + 1])
+
+
+def parse_claude_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
+    """Parse Claude CLI JSON output. Returns (text, usage)."""
+    data = _extract_json(raw_output)
+    text = data.get("result", "")
+
+    usage_data = data.get("usage", {})
+    model_usage = data.get("modelUsage", {})
+    model_name = next(iter(model_usage), "")
+
+    usage = AITokenUsage(
+        input_tokens=usage_data.get("input_tokens", 0),
+        output_tokens=usage_data.get("output_tokens", 0),
+        cache_read_tokens=usage_data.get("cache_read_input_tokens", 0),
+        cache_write_tokens=usage_data.get("cache_creation_input_tokens", 0),
+        cost_usd=data.get("total_cost_usd"),
+        duration_ms=data.get("duration_ms"),
+        model=model_name,
+        provider=provider,
+    )
+    return text, usage
+
+
+def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
+    """Parse Cursor CLI JSON output. Returns (text, usage)."""
+    data = _extract_json(raw_output)
+    text = data.get("result", "")
+
+    usage_data = data.get("usage", {})
+
+    usage = AITokenUsage(
+        input_tokens=usage_data.get("inputTokens", 0),
+        output_tokens=usage_data.get("outputTokens", 0),
+        cache_read_tokens=usage_data.get("cacheReadTokens", 0),
+        cache_write_tokens=usage_data.get("cacheWriteTokens", 0),
+        duration_ms=data.get("duration_ms"),
+        provider=provider,
+    )
+    return text, usage
+
+
+def parse_gemini_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
+    """Parse Gemini CLI JSON output. Returns (text, usage).
+
+    Note: text field is 'response' not 'result'.
+    Note: Gemini may use multiple models (e.g., router + main); tokens and
+          duration are aggregated across all models.
+    Note: output tokens are 'candidates' + 'thoughts' (thinking model tokens).
+    """
+    data = _extract_json(raw_output)
+    text = data.get("response", "")
+
+    stats = data.get("stats", {})
+    models = stats.get("models", {})
+
+    total_input = 0
+    total_output = 0
+    total_cached = 0
+    total_duration = 0
+    model_names = []
+
+    for model_name, model_data in models.items():
+        model_names.append(model_name)
+        tokens = model_data.get("tokens", {})
+        api = model_data.get("api", {})
+
+        total_input += tokens.get("input", 0)
+        total_output += tokens.get("candidates", 0) + tokens.get("thoughts", 0)
+        total_cached += tokens.get("cached", 0)
+        total_duration += api.get("totalLatencyMs", 0)
+
+    usage = AITokenUsage(
+        input_tokens=total_input,
+        output_tokens=total_output,
+        cache_read_tokens=total_cached,
+        cache_write_tokens=0,
+        duration_ms=total_duration if total_duration > 0 else None,
+        model=", ".join(model_names),
+        provider=provider,
+    )
+    return text, usage
+
+
+def parse_json_output(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
+    """Route to the correct provider parser.
+
+    Best-effort: if parsing fails, log warning and return (raw_output, None).
+    """
+    # Lazy import to avoid circular dependency (providers imports parsers at module level)
+    from ai_cli_runner.providers import PROVIDERS
+
+    config = PROVIDERS.get(provider)
+    if config is None or config.parse_json is None:
+        logger.warning("No JSON parser for provider '%s'; returning raw output", provider)
+        return raw_output, None
+
+    try:
+        return config.parse_json(raw_output, provider)
+    except Exception:
+        logger.warning("Failed to parse JSON output from '%s'; returning raw output", provider, exc_info=True)
+        return raw_output, None

--- a/src/ai_cli_runner/parsers.py
+++ b/src/ai_cli_runner/parsers.py
@@ -127,6 +127,6 @@ def parse_json_output(raw_output: str, provider: str) -> tuple[str, AITokenUsage
 
     try:
         return config.parse_json(raw_output, provider)
-    except Exception:
+    except Exception:  # noqa: BLE001 — best-effort: never raise to caller
         logger.warning("Failed to parse JSON output from '%s'; returning raw output", provider, exc_info=True)
         return raw_output, None

--- a/src/ai_cli_runner/providers.py
+++ b/src/ai_cli_runner/providers.py
@@ -1,6 +1,15 @@
-from collections.abc import Callable
+from __future__ import annotations
+
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ai_cli_runner.parsers import parse_claude_json, parse_cursor_json, parse_gemini_json
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from ai_cli_runner.models import AITokenUsage
 
 
 @dataclass(frozen=True)
@@ -9,6 +18,7 @@ class ProviderConfig:
 
     binary: str
     build_cmd: Callable[[str, str, Path | None, list[str]], list[str]]
+    parse_json: Callable[[str, str], tuple[str, AITokenUsage | None]] | None = None
 
 
 def _build_claude_cmd(binary: str, model: str, _cwd: Path | None, cli_flags: list[str]) -> list[str]:
@@ -29,9 +39,9 @@ def _build_cursor_cmd(binary: str, model: str, cwd: Path | None, cli_flags: list
 
 
 PROVIDERS: dict[str, ProviderConfig] = {
-    "claude": ProviderConfig(binary="claude", build_cmd=_build_claude_cmd),
-    "gemini": ProviderConfig(binary="gemini", build_cmd=_build_gemini_cmd),
-    "cursor": ProviderConfig(binary="agent", build_cmd=_build_cursor_cmd),
+    "claude": ProviderConfig(binary="claude", build_cmd=_build_claude_cmd, parse_json=parse_claude_json),
+    "gemini": ProviderConfig(binary="gemini", build_cmd=_build_gemini_cmd, parse_json=parse_gemini_json),
+    "cursor": ProviderConfig(binary="agent", build_cmd=_build_cursor_cmd, parse_json=parse_cursor_json),
 }
 
 VALID_AI_PROVIDERS: frozenset[str] = frozenset(PROVIDERS.keys())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -216,8 +216,8 @@ class TestCallAiCli:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=claude_response, stderr="")
         result = await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4", output_format="json")
         cmd = mock_run.call_args[0][0]
-        assert "--output-format" in cmd
-        assert "json" in cmd
+        idx = cmd.index("--output-format")
+        assert cmd[idx + 1] == "json"
         assert result.success is True
         assert result.text == "Hello!"
         assert result.usage is not None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,6 +15,7 @@ from ai_cli_runner.client import (
     check_ai_cli_available,
     get_ai_cli_timeout,
 )
+from ai_cli_runner.models import AIResult
 
 
 async def fake_to_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
@@ -186,6 +187,74 @@ class TestCallAiCli:
         success, output = await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4", ai_cli_timeout=-5)
         assert success is False
         assert "Invalid ai_cli_timeout" in output
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_returns_ai_result(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        result = await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4")
+        assert isinstance(result, AIResult)
+        assert result.success is True
+        assert result.text == "AI response"
+        assert result.usage is None
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_output_format_json_adds_flag(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        import json
+
+        claude_response = json.dumps(
+            {
+                "type": "result",
+                "result": "Hello!",
+                "duration_ms": 100,
+                "total_cost_usd": 0.01,
+                "usage": {"input_tokens": 5, "output_tokens": 3},
+                "modelUsage": {"opus-4": {}},
+            }
+        )
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=claude_response, stderr="")
+        result = await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4", output_format="json")
+        cmd = mock_run.call_args[0][0]
+        assert "--output-format" in cmd
+        assert "json" in cmd
+        assert result.success is True
+        assert result.text == "Hello!"
+        assert result.usage is not None
+        assert result.usage.input_tokens == 5
+        assert result.usage.output_tokens == 3
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_output_format_json_with_cli_flags(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        import json
+
+        claude_response = json.dumps({"result": "ok", "usage": {}, "modelUsage": {}})
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=claude_response, stderr="")
+        await call_ai_cli(
+            prompt="hello",
+            ai_provider="claude",
+            ai_model="opus-4",
+            output_format="json",
+            cli_flags=["--dangerously-skip-permissions"],
+        )
+        cmd = mock_run.call_args[0][0]
+        # --output-format json should be before the user's cli_flags
+        assert cmd == [
+            "claude",
+            "--model",
+            "opus-4",
+            "-p",
+            "--output-format",
+            "json",
+            "--dangerously-skip-permissions",
+        ]
+
+    async def test_error_returns_ai_result(self) -> None:
+        result = await call_ai_cli(prompt="hello", ai_provider="unknown", ai_model="model")
+        assert isinstance(result, AIResult)
+        assert result.success is False
+        assert "Unknown AI provider" in result.text
 
 
 class TestCheckAiCliAvailable:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,85 @@
+from ai_cli_runner.models import AIResult, AITokenUsage
+
+
+class TestAITokenUsage:
+    def test_defaults(self) -> None:
+        usage = AITokenUsage()
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.cache_read_tokens == 0
+        assert usage.cache_write_tokens == 0
+        assert usage.cost_usd is None
+        assert usage.duration_ms is None
+        assert usage.model == ""
+        assert usage.provider == ""
+
+    def test_custom_values(self) -> None:
+        usage = AITokenUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=200,
+            cache_write_tokens=300,
+            cost_usd=0.05,
+            duration_ms=1234,
+            model="opus-4",
+            provider="claude",
+        )
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.cache_read_tokens == 200
+        assert usage.cache_write_tokens == 300
+        assert usage.cost_usd == 0.05
+        assert usage.duration_ms == 1234
+        assert usage.model == "opus-4"
+        assert usage.provider == "claude"
+
+
+class TestAIResult:
+    def test_tuple_unpacking(self) -> None:
+        result = AIResult(success=True, text="hello")
+        success, text = result
+        assert success is True
+        assert text == "hello"
+
+    def test_tuple_unpacking_failure(self) -> None:
+        result = AIResult(success=False, text="error msg")
+        success, text = result
+        assert success is False
+        assert text == "error msg"
+
+    def test_index_access(self) -> None:
+        result = AIResult(success=True, text="output")
+        assert result[0] is True
+        assert result[1] == "output"
+
+    def test_len(self) -> None:
+        result = AIResult(success=True, text="hi")
+        assert len(result) == 2
+
+    def test_with_usage(self) -> None:
+        usage = AITokenUsage(input_tokens=10, output_tokens=5)
+        result = AIResult(success=True, text="hi", usage=usage)
+        assert result.usage is not None
+        assert result.usage.input_tokens == 10
+        assert result.usage.output_tokens == 5
+
+    def test_without_usage(self) -> None:
+        result = AIResult(success=True, text="hi")
+        assert result.usage is None
+
+    def test_bool_true_on_success(self) -> None:
+        result = AIResult(success=True, text="ok")
+        assert bool(result) is True
+
+    def test_bool_false_on_failure(self) -> None:
+        result = AIResult(success=False, text="error")
+        assert bool(result) is False
+
+    def test_usage_not_in_tuple_unpacking(self) -> None:
+        usage = AITokenUsage(input_tokens=10)
+        result = AIResult(success=True, text="hi", usage=usage)
+        success, text = result
+        assert success is True
+        assert text == "hi"
+        # usage is still accessible via attribute
+        assert result.usage is usage

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -106,9 +106,9 @@ class TestExtractJson:
         with pytest.raises(json.JSONDecodeError):
             _extract_json("no json here at all")
 
-    def test_no_brace_raises(self) -> None:
+    def test_closing_brace_only_raises(self) -> None:
         with pytest.raises(json.JSONDecodeError):
-            _extract_json("just plain text")
+            _extract_json("text with } but no opening brace")
 
     def test_invalid_json_after_brace_raises(self) -> None:
         with pytest.raises(json.JSONDecodeError):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from ai_cli_runner.models import AITokenUsage
+
+from ai_cli_runner.parsers import (
+    _extract_json,
+    parse_claude_json,
+    parse_cursor_json,
+    parse_gemini_json,
+    parse_json_output,
+)
+
+CLAUDE_JSON = json.dumps(
+    {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "duration_ms": 2647,
+        "duration_api_ms": 2581,
+        "result": "\n\nHi!",
+        "total_cost_usd": 0.0807275,
+        "usage": {
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 11936,
+            "cache_read_input_tokens": 11925,
+            "output_tokens": 6,
+        },
+        "modelUsage": {
+            "claude-opus-4-6[1m]": {
+                "inputTokens": 3,
+                "outputTokens": 6,
+                "cacheReadInputTokens": 11925,
+                "cacheCreationInputTokens": 11936,
+                "costUSD": 0.0807275,
+            }
+        },
+    }
+)
+
+CURSOR_JSON = json.dumps(
+    {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "duration_ms": 6661,
+        "duration_api_ms": 6661,
+        "result": "Hi — good to meet you. How can I help you today?",
+        "session_id": "abc123",
+        "usage": {
+            "inputTokens": 3602,
+            "outputTokens": 61,
+            "cacheReadTokens": 9728,
+            "cacheWriteTokens": 0,
+        },
+    }
+)
+
+GEMINI_JSON_BODY = json.dumps(
+    {
+        "session_id": "sess456",
+        "response": "Hi!",
+        "stats": {
+            "models": {
+                "gemini-3.1-pro-preview": {
+                    "api": {
+                        "totalRequests": 1,
+                        "totalErrors": 0,
+                        "totalLatencyMs": 5371,
+                    },
+                    "tokens": {
+                        "input": 10288,
+                        "candidates": 2,
+                        "total": 10638,
+                        "cached": 0,
+                        "thoughts": 348,
+                        "tool": 0,
+                    },
+                }
+            }
+        },
+    }
+)
+
+GEMINI_JSON_WITH_NOISE = (
+    'Skill "something" is overriding the built-in skill.\nAnother warning line\n' + GEMINI_JSON_BODY
+)
+
+
+class TestExtractJson:
+    def test_clean_json(self) -> None:
+        data = _extract_json('{"key": "value"}')
+        assert data == {"key": "value"}
+
+    def test_json_with_noise_prefix(self) -> None:
+        raw = 'Some warning line\nAnother line\n{"key": "value"}'
+        data = _extract_json(raw)
+        assert data == {"key": "value"}
+
+    def test_no_json_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            _extract_json("no json here at all")
+
+    def test_no_brace_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            _extract_json("just plain text")
+
+    def test_invalid_json_after_brace_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            _extract_json("noise {not valid json")
+
+    def test_json_with_trailing_noise(self) -> None:
+        raw = '{"key": "value"}\nSome trailing text'
+        data = _extract_json(raw)
+        assert data == {"key": "value"}
+
+    def test_json_with_both_prefix_and_suffix_noise(self) -> None:
+        raw = 'Warning line\n{"key": "value"}\nDone.'
+        data = _extract_json(raw)
+        assert data == {"key": "value"}
+
+
+class TestParseClaudeJson:
+    @pytest.fixture()
+    def parsed(self) -> tuple[str, AITokenUsage | None]:
+        return parse_claude_json(CLAUDE_JSON, "claude")
+
+    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        text, _usage = parsed
+        assert text == "\n\nHi!"
+
+    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.input_tokens == 3
+
+    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.output_tokens == 6
+
+    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.cache_read_tokens == 11925
+
+    def test_parses_cache_write_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.cache_write_tokens == 11936
+
+    def test_parses_cost(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.cost_usd == 0.0807275
+
+    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.duration_ms == 2647
+
+    def test_parses_model(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.model == "claude-opus-4-6[1m]"
+
+    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.provider == "claude"
+
+
+class TestParseCursorJson:
+    @pytest.fixture()
+    def parsed(self) -> tuple[str, AITokenUsage | None]:
+        return parse_cursor_json(CURSOR_JSON, "cursor")
+
+    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        text, _usage = parsed
+        assert text == "Hi — good to meet you. How can I help you today?"
+
+    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.input_tokens == 3602
+
+    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.output_tokens == 61
+
+    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.cache_read_tokens == 9728
+
+    def test_parses_cache_write_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.cache_write_tokens == 0
+
+    def test_no_cost(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.cost_usd is None
+
+    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.duration_ms == 6661
+
+    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.provider == "cursor"
+
+
+class TestParseGeminiJson:
+    @pytest.fixture()
+    def parsed(self) -> tuple[str, AITokenUsage | None]:
+        return parse_gemini_json(GEMINI_JSON_BODY, "gemini")
+
+    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        text, _usage = parsed
+        assert text == "Hi!"
+
+    def test_parses_text_with_noise(self) -> None:
+        text, _usage = parse_gemini_json(GEMINI_JSON_WITH_NOISE, "gemini")
+        assert text == "Hi!"
+
+    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.input_tokens == 10288
+
+    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.output_tokens == 350
+
+    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.cache_read_tokens == 0
+
+    def test_cache_write_tokens_zero(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.cache_write_tokens == 0
+
+    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.duration_ms == 5371
+
+    def test_parses_model(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.model == "gemini-3.1-pro-preview"
+
+    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.provider == "gemini"
+
+    def test_aggregates_multiple_models(self) -> None:
+        """Gemini may use multiple models (router + main); verify aggregation."""
+        multi_model_json = json.dumps(
+            {
+                "response": "Hello!",
+                "stats": {
+                    "models": {
+                        "gemini-2.5-flash-lite": {
+                            "api": {"totalLatencyMs": 1386},
+                            "tokens": {"input": 1197, "candidates": 50, "cached": 0, "thoughts": 127},
+                        },
+                        "gemini-3-flash-preview": {
+                            "api": {"totalLatencyMs": 1124},
+                            "tokens": {"input": 8468, "candidates": 24, "cached": 0, "thoughts": 0},
+                        },
+                    }
+                },
+            }
+        )
+        text, usage = parse_gemini_json(multi_model_json, "gemini")
+        assert text == "Hello!"
+        assert usage is not None
+        assert usage.input_tokens == 1197 + 8468  # sum across models
+        assert usage.output_tokens == (50 + 127) + (24 + 0)  # candidates + thoughts per model
+        assert usage.cache_read_tokens == 0
+        assert usage.duration_ms == 1386 + 1124  # sum of latencies
+        assert usage.model == "gemini-2.5-flash-lite, gemini-3-flash-preview"
+        assert usage.provider == "gemini"
+
+
+class TestParseJsonOutput:
+    def test_routes_to_claude(self) -> None:
+        text, usage = parse_json_output(CLAUDE_JSON, "claude")
+        assert text == "\n\nHi!"
+        assert usage is not None
+        assert usage.provider == "claude"
+
+    def test_routes_to_cursor(self) -> None:
+        text, usage = parse_json_output(CURSOR_JSON, "cursor")
+        assert text == "Hi — good to meet you. How can I help you today?"
+        assert usage is not None
+        assert usage.provider == "cursor"
+
+    def test_routes_to_gemini(self) -> None:
+        text, usage = parse_json_output(GEMINI_JSON_BODY, "gemini")
+        assert text == "Hi!"
+        assert usage is not None
+        assert usage.provider == "gemini"
+
+    def test_unknown_provider_returns_raw(self) -> None:
+        text, usage = parse_json_output("raw output", "unknown_provider")
+        assert text == "raw output"
+        assert usage is None
+
+    def test_invalid_json_returns_raw(self) -> None:
+        text, usage = parse_json_output("not json at all", "claude")
+        assert text == "not json at all"
+        assert usage is None
+
+    def test_best_effort_no_exception(self) -> None:
+        # Should never raise, even with garbage input
+        text, usage = parse_json_output("", "gemini")
+        assert text == ""
+        assert usage is None

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -219,6 +219,11 @@ class TestParseCursorJson:
         assert usage is not None
         assert usage.provider == "cursor"
 
+    def test_model_empty_by_design(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.model == ""
+
 
 class TestParseGeminiJson:
     @pytest.fixture()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from ai_cli_runner.parsers import parse_claude_json, parse_cursor_json, parse_gemini_json
 from ai_cli_runner.providers import (
     PROVIDERS,
     VALID_AI_PROVIDERS,
@@ -27,6 +28,14 @@ class TestProviderConfig:
         config = ProviderConfig(binary="claude", build_cmd=_build_claude_cmd)
         cmd = config.build_cmd(config.binary, "opus-4", None, [])
         assert cmd == ["claude", "--model", "opus-4", "-p"]
+
+    async def test_parse_json_default_none(self) -> None:
+        config = ProviderConfig(binary="test", build_cmd=_build_claude_cmd)
+        assert config.parse_json is None
+
+    async def test_parse_json_attribute(self) -> None:
+        config = ProviderConfig(binary="test", build_cmd=_build_claude_cmd, parse_json=parse_claude_json)
+        assert config.parse_json is parse_claude_json
 
 
 class TestBuildClaudeCmd:
@@ -100,16 +109,19 @@ class TestProvidersDict:
         config = PROVIDERS["claude"]
         assert config.binary == "claude"
         assert config.build_cmd is _build_claude_cmd
+        assert config.parse_json is parse_claude_json
 
     async def test_gemini_provider(self) -> None:
         config = PROVIDERS["gemini"]
         assert config.binary == "gemini"
         assert config.build_cmd is _build_gemini_cmd
+        assert config.parse_json is parse_gemini_json
 
     async def test_cursor_provider(self) -> None:
         config = PROVIDERS["cursor"]
         assert config.binary == "agent"
         assert config.build_cmd is _build_cursor_cmd
+        assert config.parse_json is parse_cursor_json
 
     async def test_valid_ai_providers_matches_keys(self) -> None:
         assert set(PROVIDERS.keys()) == VALID_AI_PROVIDERS

--- a/tox.toml
+++ b/tox.toml
@@ -8,7 +8,7 @@ commands = [
   [
     "uv",
     "run",
-    "--extra",
+    "--group",
     "dev",
     "pytest",
     "-n",

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,13 @@ dev = [
     { name = "pytest-xdist" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
@@ -27,6 +34,13 @@ requires-dist = [
     { name = "python-simple-logger" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "ruff", specifier = ">=0.15.11" },
+]
 
 [[package]]
 name = "colorama"
@@ -255,6 +269,31 @@ dependencies = [
     { name = "colorlog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/5b/e97b2209a7de9763c50ef073620630aff8ffc546206e519f1d4330293f9c/python_simple_logger-2.0.19.tar.gz", hash = "sha256:1a26cf71da4bea84ac3093a90a2476555a8dde5cce69c8271143eea7675ca9e1", size = 9953, upload-time = "2026-02-26T09:36:04.764Z" }
+
+[[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
 
 [[package]]
 name = "typing-extensions"

--- a/uv.lock
+++ b/uv.lock
@@ -10,35 +10,24 @@ dependencies = [
     { name = "python-simple-logger" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'" },
-    { name = "pytest-xdist", marker = "extra == 'dev'" },
-    { name = "python-simple-logger" },
-]
-provides-extras = ["dev"]
+requires-dist = [{ name = "python-simple-logger" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-xdist" },
     { name = "ruff", specifier = ">=0.15.11" },
 ]
 


### PR DESCRIPTION
## Summary

Adds `output_format="json"` support to `call_ai_cli()` so callers can get token usage metadata alongside the response text.

## Changes

### New Files
- **`src/ai_cli_runner/models.py`** — `AIResult` and `AITokenUsage` dataclasses
- **`src/ai_cli_runner/parsers.py`** — Provider-specific JSON parsers for Claude, Cursor, and Gemini
- **`tests/test_models.py`** — Tests for dataclasses (tuple unpacking, bool, indexing)
- **`tests/test_parsers.py`** — Tests for all 3 parsers with real JSON fixtures

### Modified Files
- **`src/ai_cli_runner/client.py`** — `call_ai_cli()` accepts `output_format` param, returns `AIResult`
- **`src/ai_cli_runner/providers.py`** — Added `parse_json` field to `ProviderConfig`
- **`src/ai_cli_runner/__init__.py`** — Exports `AIResult`, `AITokenUsage`, `parse_json_output`
- **`README.md`** — Documented JSON output / token usage feature

## Key Design Decisions

- **Backward compatible** — `AIResult` supports `__iter__`/`__getitem__`/`__len__` so `success, text = await call_ai_cli(...)` still works
- **`AIResult.__bool__`** returns `self.success` for intuitive `if result:` checks
- **Best-effort parsing** — JSON parse failures log a warning and return raw output with `usage=None`
- **Gemini output_tokens** includes `candidates + thoughts` (thinking model tokens)
- **Single source of truth** — `parse_json_output()` uses `PROVIDERS[provider].parse_json` instead of a duplicate routing dict

## Verified

- ✅ 124 tests pass
- ✅ Live-tested with Gemini CLI and Cursor CLI
- ✅ Parsed exact JSON from real Claude, Cursor, and Gemini CLI runs

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI call API supports optional JSON output, returning structured results (success, text, usage) with tuple-unpacking and boolean-evaluation behavior; provider-aware usage aggregation.

* **Documentation**
  * README updated with JSON-mode examples, field schemas, parsing notes, and provider support matrix.

* **Tests**
  * Added/updated tests for JSON parsing, result behavior, and usage fields across providers.

* **Chores**
  * Moved dev dependencies into a dependency-group with explicit tool versions.

* **Style**
  * Lint selection updated to include additional rule family.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->