### PR TITLE
feat: add session support (continue/resume) to call_ai_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ All providers support multi-turn conversations via sessions. Use `output_format=
 result = await call_ai_cli(
     prompt="My name is Alice.",
     ai_provider="claude",
-    ai_model="claude-haiku-4-5",
+    ai_model="claude-haiku-4-20250514",
     output_format="json",
 )
 session_id = result.session_id  # capture for later
@@ -107,7 +107,7 @@ session_id = result.session_id  # capture for later
 followup = await call_ai_cli(
     prompt="What is my name?",
     ai_provider="claude",
-    ai_model="claude-haiku-4-5",
+    ai_model="claude-haiku-4-20250514",
     output_format="json",
     session_id=session_id,
 )
@@ -116,7 +116,7 @@ followup = await call_ai_cli(
 continued = await call_ai_cli(
     prompt="Thanks!",
     ai_provider="claude",
-    ai_model="claude-haiku-4-5",
+    ai_model="claude-haiku-4-20250514",
     output_format="json",
     continue_session=True,
 )

--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ See [`examples/`](examples/) for complete usage:
 | [`basic_call.py`](examples/basic_call.py) | Parallel calls to all 3 providers with token usage |
 | [`with_pricing.py`](examples/with_pricing.py) | LLM cost tracking via LiteLLM pricing |
 | [`model_listing.py`](examples/model_listing.py) | List models, validate names, check CLI availability |
+| [`session_usage.py`](examples/session_usage.py) | Session management — start, resume, and continue |
 
 Run any example: `uv run examples/basic_call.py`
 
 ## API
 
-### `call_ai_cli(prompt, cwd, ai_provider, ai_model, ai_cli_timeout, cli_flags, output_format) → AIResult`
+### `call_ai_cli(prompt, cwd, ai_provider, ai_model, ai_cli_timeout, cli_flags, output_format, session_id, continue_session) → AIResult`
 
-Call an AI CLI tool. Pass `output_format="json"` to get structured token usage.
+Call an AI CLI tool. Pass `output_format="json"` to get structured token usage and session IDs.
 
 ### `check_ai_cli_available(ai_provider, ai_model, cli_flags) → AIResult`
 
@@ -59,6 +60,7 @@ Send a trivial prompt to verify the CLI is installed and working.
 | `success` | `bool` | Whether the call succeeded |
 | `text` | `str` | Response text |
 | `usage` | `AITokenUsage \| None` | Token usage (when `output_format="json"`) |
+| `session_id` | `str \| None` | Session ID for resuming (when `output_format="json"`) |
 
 Supports tuple unpacking (`success, text = await call_ai_cli(...)`) and boolean evaluation (`if result: ...`).
 
@@ -74,6 +76,7 @@ Supports tuple unpacking (`success, text = await call_ai_cli(...)`) and boolean 
 | `duration_ms` | `int \| None` | Wall-clock duration |
 | `model` | `str` | Model used |
 | `provider` | `str` | Provider name |
+| `session_id` | `str` | Session ID from provider response |
 
 ### Cost Calculation
 
@@ -85,6 +88,41 @@ from ai_cli_runner import pricing_cache
 await pricing_cache.load()  # call once at startup
 # cost_usd is now auto-populated on all output_format="json" calls
 ```
+
+### Session Management
+
+All providers support multi-turn conversations via sessions. Use `output_format="json"` to get session IDs:
+
+```python
+# Start a session
+result = await call_ai_cli(
+    prompt="My name is Alice.",
+    ai_provider="claude",
+    ai_model="claude-haiku-4-5",
+    output_format="json",
+)
+session_id = result.session_id  # capture for later
+
+# Resume by session ID
+followup = await call_ai_cli(
+    prompt="What is my name?",
+    ai_provider="claude",
+    ai_model="claude-haiku-4-5",
+    output_format="json",
+    session_id=session_id,
+)
+
+# Continue the most recent session (no ID needed)
+continued = await call_ai_cli(
+    prompt="Thanks!",
+    ai_provider="claude",
+    ai_model="claude-haiku-4-5",
+    output_format="json",
+    continue_session=True,
+)
+```
+
+`session_id` and `continue_session` are mutually exclusive.
 
 ### Model Listing & Validation
 
@@ -98,11 +136,11 @@ is_valid = model_cache.is_valid_model("claude", "claude-haiku-4-20250514")
 
 ## Supported Providers
 
-| Provider | Binary | Notes |
-|----------|--------|-------|
-| `claude` | `claude` | `-p` flag for non-interactive mode |
-| `gemini` | `gemini` | Stdin prompt |
-| `cursor` | `agent` | `--workspace` for cwd |
+| Provider | Binary | Notes | Session flags |
+|----------|--------|-------|---------------|
+| `claude` | `claude` | `-p` flag for non-interactive mode | `--continue`, `--resume <id>` |
+| `gemini` | `gemini` | Stdin prompt | `--resume`, `--resume <id>` |
+| `cursor` | `agent` | `--workspace` for cwd | `--continue`, `--resume <id>` |
 
 ## Environment Variables
 

--- a/examples/session_usage.py
+++ b/examples/session_usage.py
@@ -1,0 +1,75 @@
+# Run: uv run examples/session_usage.py
+
+"""Example: session management — start, resume, and continue sessions."""
+
+import asyncio
+
+from ai_cli_runner import call_ai_cli
+
+CLAUDE_MODEL = "claude-haiku-4-5"
+CLAUDE_FLAGS = ["--dangerously-skip-permissions"]
+TIMEOUT_MINUTES = 2
+
+
+async def main() -> None:
+    # Step 1: Start a new session
+    print("--- Starting new session ---")
+    result = await call_ai_cli(
+        prompt="My name is Alice. Remember that.",
+        ai_provider="claude",
+        ai_model=CLAUDE_MODEL,
+        ai_cli_timeout=TIMEOUT_MINUTES,
+        cli_flags=CLAUDE_FLAGS,
+        output_format="json",
+    )
+
+    if not result.success:
+        print(f"Error: {result.text}")
+        return
+
+    print(f"Response: {result.text}")
+    print(f"Session ID: {result.session_id}")
+
+    if not result.session_id:
+        print("No session ID returned — session features require output_format='json'")
+        return
+
+    # Step 2: Resume the session by ID with a follow-up question
+    print("\n--- Resuming session by ID ---")
+    followup = await call_ai_cli(
+        prompt="What is my name?",
+        ai_provider="claude",
+        ai_model=CLAUDE_MODEL,
+        ai_cli_timeout=TIMEOUT_MINUTES,
+        cli_flags=CLAUDE_FLAGS,
+        output_format="json",
+        session_id=result.session_id,
+    )
+
+    if followup.success:
+        print(f"Response: {followup.text}")
+        print(f"Session ID: {followup.session_id}")
+    else:
+        print(f"Error: {followup.text}")
+
+    # Step 3: Continue the most recent session (no ID needed)
+    print("\n--- Continuing most recent session ---")
+    continued = await call_ai_cli(
+        prompt="And what did I ask you to remember?",
+        ai_provider="claude",
+        ai_model=CLAUDE_MODEL,
+        ai_cli_timeout=TIMEOUT_MINUTES,
+        cli_flags=CLAUDE_FLAGS,
+        output_format="json",
+        continue_session=True,
+    )
+
+    if continued.success:
+        print(f"Response: {continued.text}")
+        print(f"Session ID: {continued.session_id}")
+    else:
+        print(f"Error: {continued.text}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -182,7 +182,7 @@ async def call_ai_cli(
     if config is None:  # defensive: guaranteed by _validate_provider_and_model
         raise RuntimeError("ProviderConfig unexpectedly None after validation")
 
-    if session_id and continue_session:
+    if session_id is not None and continue_session:
         return AIResult(
             success=False,
             text=(
@@ -223,7 +223,7 @@ async def call_ai_cli(
 
     if continue_session:
         effective_cli_flags.extend(config.continue_flags)
-    elif session_id:
+    elif session_id is not None:
         effective_cli_flags.extend([config.resume_flag, session_id])
 
     cmd = config.build_cmd(config.binary, ai_model, cwd, effective_cli_flags)

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -145,6 +145,8 @@ async def call_ai_cli(
     ai_cli_timeout: int | None = None,
     cli_flags: list[str] | None = None,
     output_format: Literal["json"] | None = None,
+    session_id: str | None = None,
+    continue_session: bool = False,
 ) -> AIResult:
     """Call AI CLI (Claude, Gemini, or Cursor) with given prompt.
 
@@ -156,15 +158,22 @@ async def call_ai_cli(
         ai_cli_timeout: Timeout in minutes (overrides AI_CLI_TIMEOUT env var).
         cli_flags: Extra CLI flags to pass to the provider command.
         output_format: Output format ("json" or None). When set, parses structured output.
+        session_id: Resume a specific session by ID. Mutually exclusive with continue_session.
+        continue_session: Continue the most recent session. Mutually exclusive with session_id.
 
     Returns:
-        AIResult with success status, text output, and optional usage metadata.
+        AIResult with success status, text output, optional usage metadata, and session_id.
         Supports tuple unpacking: success, text = await call_ai_cli(...)
 
     Note:
         Cost calculation via LiteLLM pricing requires ``await pricing_cache.load()``
         at application startup. Without it, ``cost_usd`` will only be populated
         for providers that report it natively (e.g., Claude).
+
+        Session parameters (``session_id``, ``continue_session``) work with any
+        output format — the CLI will resume/continue the conversation regardless.
+        However, ``AIResult.session_id`` is only populated when ``output_format="json"``
+        is set, since session IDs are extracted from the JSON response.
     """
     valid, error_msg, config = _validate_provider_and_model(ai_provider, ai_model)
     if not valid:
@@ -172,6 +181,16 @@ async def call_ai_cli(
 
     if config is None:  # defensive: guaranteed by _validate_provider_and_model
         raise RuntimeError("ProviderConfig unexpectedly None after validation")
+
+    if session_id and continue_session:
+        return AIResult(
+            success=False,
+            text=(
+                "Cannot use both session_id and continue_session."
+                " Use session_id to resume a specific session,"
+                " or continue_session to continue the most recent session."
+            ),
+        )
 
     provider_info = f"{ai_provider.upper()} ({ai_model})"
 
@@ -201,6 +220,11 @@ async def call_ai_cli(
                 output_format,
             )
         effective_cli_flags = ["--output-format", output_format, *cleaned_flags]
+
+    if continue_session:
+        effective_cli_flags.extend(config.continue_flags)
+    elif session_id:
+        effective_cli_flags.extend([config.resume_flag, session_id])
 
     cmd = config.build_cmd(config.binary, ai_model, cwd, effective_cli_flags)
 
@@ -260,7 +284,9 @@ async def call_ai_cli(
                 output_format,
                 len(result.stdout),
             )
-        return AIResult(success=True, text=text, usage=usage)
+        # Bridge AITokenUsage.session_id (str, defaults "") → AIResult.session_id (str | None)
+        session = usage.session_id if usage else None
+        return AIResult(success=True, text=text, usage=usage, session_id=session or None)
 
     return AIResult(success=True, text=result.stdout)
 

--- a/src/ai_cli_runner/models.py
+++ b/src/ai_cli_runner/models.py
@@ -19,6 +19,7 @@ class AITokenUsage:
     duration_ms: int | None = None
     model: str = ""
     provider: str = ""
+    session_id: str = ""
 
 
 @dataclass
@@ -32,6 +33,7 @@ class AIResult:
     success: bool
     text: str
     usage: AITokenUsage | None = None
+    session_id: str | None = None
 
     def __iter__(self) -> Iterator[Any]:
         """Support tuple unpacking for backward compatibility.

--- a/src/ai_cli_runner/parsers.py
+++ b/src/ai_cli_runner/parsers.py
@@ -48,6 +48,7 @@ def parse_claude_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
         duration_ms=data.get("duration_ms"),
         model=model_name,
         provider=provider,
+        session_id=data.get("session_id", ""),
     )
     return text, usage
 
@@ -66,6 +67,7 @@ def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
         cache_write_tokens=usage_data.get("cacheWriteTokens", 0),
         duration_ms=data.get("duration_ms"),
         provider=provider,
+        session_id=data.get("session_id", ""),
     )
     return text, usage
 
@@ -117,6 +119,7 @@ def parse_gemini_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
         duration_ms=total_duration if total_duration > 0 else None,
         model=primary_model,
         provider=provider,
+        session_id=data.get("session_id", ""),
     )
     return text, usage
 

--- a/src/ai_cli_runner/providers.py
+++ b/src/ai_cli_runner/providers.py
@@ -19,6 +19,8 @@ class ProviderConfig:
     binary: str
     build_cmd: Callable[[str, str, Path | None, list[str]], list[str]]
     parse_json: Callable[[str, str], tuple[str, AITokenUsage | None]] | None = None
+    continue_flags: tuple[str, ...] = ()
+    resume_flag: str = ""
 
 
 def _build_claude_cmd(binary: str, model: str, _cwd: Path | None, cli_flags: list[str]) -> list[str]:
@@ -39,9 +41,28 @@ def _build_cursor_cmd(binary: str, model: str, cwd: Path | None, cli_flags: list
 
 
 PROVIDERS: dict[str, ProviderConfig] = {
-    "claude": ProviderConfig(binary="claude", build_cmd=_build_claude_cmd, parse_json=parse_claude_json),
-    "gemini": ProviderConfig(binary="gemini", build_cmd=_build_gemini_cmd, parse_json=parse_gemini_json),
-    "cursor": ProviderConfig(binary="agent", build_cmd=_build_cursor_cmd, parse_json=parse_cursor_json),
+    "claude": ProviderConfig(
+        binary="claude",
+        build_cmd=_build_claude_cmd,
+        parse_json=parse_claude_json,
+        continue_flags=("--continue",),
+        resume_flag="--resume",
+    ),
+    "gemini": ProviderConfig(
+        binary="gemini",
+        build_cmd=_build_gemini_cmd,
+        parse_json=parse_gemini_json,
+        # Gemini uses --resume for both: no arg = continue latest, with ID = resume specific
+        continue_flags=("--resume",),
+        resume_flag="--resume",
+    ),
+    "cursor": ProviderConfig(
+        binary="agent",
+        build_cmd=_build_cursor_cmd,
+        parse_json=parse_cursor_json,
+        continue_flags=("--continue",),
+        resume_flag="--resume",
+    ),
 }
 
 VALID_AI_PROVIDERS: frozenset[str] = frozenset(PROVIDERS.keys())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -257,6 +257,183 @@ class TestCallAiCli:
         assert "Unknown AI provider" in result.text
 
 
+class TestCallAiCliSession:
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_continue_session_claude_flags(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4", continue_session=True)
+        cmd = mock_run.call_args[0][0]
+        assert "--continue" in cmd
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_continue_session_gemini_flags(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        await call_ai_cli(prompt="hello", ai_provider="gemini", ai_model="flash", continue_session=True)
+        cmd = mock_run.call_args[0][0]
+        assert "--resume" in cmd
+        # gemini uses --resume with no arg for continue; verify no session id follows
+        resume_idx = cmd.index("--resume")
+        # --resume should be the last element (no arg after it)
+        assert resume_idx == len(cmd) - 1
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_continue_session_cursor_flags(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        await call_ai_cli(prompt="hello", ai_provider="cursor", ai_model="gpt-4", continue_session=True)
+        cmd = mock_run.call_args[0][0]
+        assert "--continue" in cmd
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_session_id_claude_flags(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4", session_id="sess-abc")
+        cmd = mock_run.call_args[0][0]
+        resume_idx = cmd.index("--resume")
+        assert cmd[resume_idx + 1] == "sess-abc"
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_session_id_gemini_flags(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        await call_ai_cli(prompt="hello", ai_provider="gemini", ai_model="flash", session_id="sess-def")
+        cmd = mock_run.call_args[0][0]
+        resume_idx = cmd.index("--resume")
+        assert cmd[resume_idx + 1] == "sess-def"
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_session_id_cursor_flags(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        await call_ai_cli(prompt="hello", ai_provider="cursor", ai_model="gpt-4", session_id="sess-ghi")
+        cmd = mock_run.call_args[0][0]
+        resume_idx = cmd.index("--resume")
+        assert cmd[resume_idx + 1] == "sess-ghi"
+
+    async def test_session_id_and_continue_session_mutually_exclusive(self) -> None:
+        result = await call_ai_cli(
+            prompt="hello",
+            ai_provider="claude",
+            ai_model="opus-4",
+            session_id="sess-abc",
+            continue_session=True,
+        )
+        assert result.success is False
+        assert "Cannot use both session_id and continue_session" in result.text
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_session_id_returned_from_json_output(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        import json
+
+        claude_response = json.dumps(
+            {
+                "type": "result",
+                "result": "Hello!",
+                "session_id": "test-session-abc",
+                "duration_ms": 100,
+                "total_cost_usd": 0.01,
+                "usage": {"input_tokens": 5, "output_tokens": 3},
+                "modelUsage": {"opus-4": {}},
+            }
+        )
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=claude_response, stderr="")
+        result = await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4", output_format="json")
+        assert result.session_id == "test-session-abc"
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_session_id_none_without_json_output(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        result = await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4")
+        assert result.session_id is None
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_session_id_none_when_not_in_json(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        import json
+
+        claude_response = json.dumps(
+            {
+                "type": "result",
+                "result": "Hello!",
+                "duration_ms": 100,
+                "total_cost_usd": 0.01,
+                "usage": {"input_tokens": 5, "output_tokens": 3},
+                "modelUsage": {"opus-4": {}},
+            }
+        )
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=claude_response, stderr="")
+        result = await call_ai_cli(prompt="hello", ai_provider="claude", ai_model="opus-4", output_format="json")
+        # session_id defaults to "" in AITokenUsage, which becomes None via `or None`
+        assert result.session_id is None
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_continue_session_with_cli_flags(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        mock_run.return_value = _successful_run_result()
+        await call_ai_cli(
+            prompt="hello",
+            ai_provider="claude",
+            ai_model="opus-4",
+            cli_flags=["--dangerously-skip-permissions"],
+            continue_session=True,
+        )
+        cmd = mock_run.call_args[0][0]
+        # Session flags should be appended AFTER other cli_flags
+        skip_idx = cmd.index("--dangerously-skip-permissions")
+        continue_idx = cmd.index("--continue")
+        assert continue_idx > skip_idx
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_session_id_with_output_format(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        import json
+
+        claude_response = json.dumps(
+            {
+                "type": "result",
+                "result": "Hello!",
+                "session_id": "sess-combo",
+                "duration_ms": 100,
+                "total_cost_usd": 0.01,
+                "usage": {"input_tokens": 5, "output_tokens": 3},
+                "modelUsage": {"opus-4": {}},
+            }
+        )
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=claude_response, stderr="")
+        result = await call_ai_cli(
+            prompt="hello",
+            ai_provider="claude",
+            ai_model="opus-4",
+            output_format="json",
+            session_id="sess-prev",
+        )
+        cmd = mock_run.call_args[0][0]
+        # Both --output-format json and --resume sess-prev should be in the command
+        assert "--output-format" in cmd
+        assert "json" in cmd
+        assert "--resume" in cmd
+        assert "sess-prev" in cmd
+        # Result should have session_id from the JSON response
+        assert result.session_id == "sess-combo"
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_session_flags_without_output_format(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        """Session flags are sent to CLI even without output_format; result.session_id is None."""
+        mock_run.return_value = _successful_run_result()
+        result = await call_ai_cli(prompt="hi", ai_provider="claude", ai_model="opus-4", session_id="sess-123")
+        cmd = mock_run.call_args[0][0]
+        assert "--resume" in cmd
+        assert "sess-123" in cmd
+        assert "--output-format" not in cmd
+        assert result.session_id is None
+
+
 class TestCheckAiCliAvailable:
     @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
     @patch("ai_cli_runner.client._run_with_process_group")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -33,6 +33,14 @@ class TestAITokenUsage:
         assert usage.model == "opus-4"
         assert usage.provider == "claude"
 
+    def test_session_id_default(self) -> None:
+        usage = AITokenUsage()
+        assert usage.session_id == ""
+
+    def test_session_id_custom(self) -> None:
+        usage = AITokenUsage(session_id="sess-abc-123")
+        assert usage.session_id == "sess-abc-123"
+
 
 class TestAIResult:
     def test_tuple_unpacking(self) -> None:
@@ -83,3 +91,19 @@ class TestAIResult:
         assert text == "hi"
         # usage is still accessible via attribute
         assert result.usage is usage
+
+    def test_session_id_default_none(self) -> None:
+        result = AIResult(success=True, text="hi")
+        assert result.session_id is None
+
+    def test_session_id_custom(self) -> None:
+        result = AIResult(success=True, text="hi", session_id="sess-xyz")
+        assert result.session_id == "sess-xyz"
+
+    def test_session_id_not_in_tuple_unpacking(self) -> None:
+        result = AIResult(success=True, text="hi", session_id="sess-xyz")
+        success, text = result
+        assert success is True
+        assert text == "hi"
+        # session_id is still accessible via attribute
+        assert result.session_id == "sess-xyz"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -24,6 +24,7 @@ CLAUDE_JSON = json.dumps(
         "duration_ms": 2647,
         "duration_api_ms": 2581,
         "result": "\n\nHi!",
+        "session_id": "sess-claude-123",
         "total_cost_usd": 0.0807275,
         "usage": {
             "input_tokens": 3,
@@ -174,6 +175,11 @@ class TestParseClaudeJson:
         assert usage is not None
         assert usage.provider == "claude"
 
+    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.session_id == "sess-claude-123"
+
 
 class TestParseCursorJson:
     @pytest.fixture()
@@ -224,6 +230,11 @@ class TestParseCursorJson:
         assert usage is not None
         assert usage.model == ""
 
+    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.session_id == "abc123"
+
 
 class TestParseGeminiJson:
     @pytest.fixture()
@@ -272,6 +283,34 @@ class TestParseGeminiJson:
         _, usage = parsed
         assert usage is not None
         assert usage.provider == "gemini"
+
+    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None]) -> None:
+        _, usage = parsed
+        assert usage is not None
+        assert usage.session_id == "sess456"
+
+    def test_session_id_with_noise(self) -> None:
+        _, usage = parse_gemini_json(GEMINI_JSON_WITH_NOISE, "gemini")
+        assert usage is not None
+        assert usage.session_id == "sess456"
+
+    def test_missing_session_id(self) -> None:
+        no_session_json = json.dumps(
+            {
+                "response": "Hello",
+                "stats": {
+                    "models": {
+                        "gemini-2.0-flash": {
+                            "api": {"totalLatencyMs": 100},
+                            "tokens": {"input": 10, "candidates": 5, "cached": 0, "thoughts": 0},
+                        }
+                    }
+                },
+            }
+        )
+        _, usage = parse_gemini_json(no_session_json, "gemini")
+        assert usage is not None
+        assert usage.session_id == ""
 
     def test_aggregates_multiple_models(self) -> None:
         """Gemini may use multiple models (router + main); verify aggregation."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -126,3 +126,34 @@ class TestProvidersDict:
     async def test_valid_ai_providers_matches_keys(self) -> None:
         assert set(PROVIDERS.keys()) == VALID_AI_PROVIDERS
         assert {"claude", "gemini", "cursor"} == VALID_AI_PROVIDERS
+
+
+class TestProviderSessionConfig:
+    async def test_claude_continue_flags(self) -> None:
+        config = PROVIDERS["claude"]
+        assert config.continue_flags == ("--continue",)
+
+    async def test_claude_resume_flag(self) -> None:
+        config = PROVIDERS["claude"]
+        assert config.resume_flag == "--resume"
+
+    async def test_gemini_continue_flags(self) -> None:
+        config = PROVIDERS["gemini"]
+        assert config.continue_flags == ("--resume",)
+
+    async def test_gemini_resume_flag(self) -> None:
+        config = PROVIDERS["gemini"]
+        assert config.resume_flag == "--resume"
+
+    async def test_cursor_continue_flags(self) -> None:
+        config = PROVIDERS["cursor"]
+        assert config.continue_flags == ("--continue",)
+
+    async def test_cursor_resume_flag(self) -> None:
+        config = PROVIDERS["cursor"]
+        assert config.resume_flag == "--resume"
+
+    async def test_provider_config_defaults(self) -> None:
+        config = ProviderConfig(binary="test", build_cmd=_build_claude_cmd)
+        assert config.continue_flags == ()
+        assert config.resume_flag == ""


### PR DESCRIPTION
## Summary

Adds session management to `call_ai_cli()`, allowing callers to start sessions, capture session IDs, and resume or continue previous conversations across all 3 providers.

## Changes

### API
- `call_ai_cli()` gains `session_id: str | None` and `continue_session: bool` params (mutually exclusive)
- `AIResult` gains `session_id: str | None` field (populated when `output_format="json"`)
- `AITokenUsage` gains `session_id: str` field (extracted from provider JSON)

### Provider Support
- `ProviderConfig` gains `continue_flags` and `resume_flag` fields
- Claude: `--continue` / `--resume <id>`
- Gemini: `--resume` (no arg = continue latest) / `--resume <id>`
- Cursor: `--continue` / `--resume <id>`

### Backward Compatible
All new fields have defaults — zero breaking changes for existing callers. Tuple unpacking, boolean eval, and index access all work unchanged.

### Tested
- 237 unit tests passing
- Live-tested against all 3 CLIs (claude, gemini, cursor): new session, resume by ID, continue latest
- Backward compatibility verified

## Files Changed
- `src/ai_cli_runner/models.py` — session_id fields
- `src/ai_cli_runner/providers.py` — continue_flags/resume_flag
- `src/ai_cli_runner/parsers.py` — session_id extraction
- `src/ai_cli_runner/client.py` — session params, validation, flag injection
- `tests/` — comprehensive session tests
- `examples/session_usage.py` — new example
- `README.md` — session management docs

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session management for multi-turn conversations: start sessions, resume by session ID, or continue the most recent session; resume and continue are mutually exclusive.

* **Documentation**
  * README updated with session examples, structured JSON output now includes session IDs in results and token usage, and provider session behavior documented per provider.

* **Tests**
  * Test coverage added for session handling, parsing session IDs, and provider session flags.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/myk-org/ai-cli-runner/pull/23)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->