### PR TITLE
fix: strip chain-of-thought from cursor output_format="json" result text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,9 @@ Shared async Python package for calling AI CLI tools (Claude, Gemini, Cursor) vi
 ## Project Structure
 - `src/ai_cli_runner/` — package source
   - `client.py` — main `call_ai_cli()` function, subprocess management
-  - `models.py` — `AIResult` (with `thinking` field for chain-of-thought), `AITokenUsage` dataclasses
+  - `models.py` — `AIResult` (with `thinking` field for chain-of-thought), `AITokenUsage`, `ParsedOutput` dataclasses
   - `providers.py` — provider configs (claude, gemini, cursor)
-  - `parsers.py` — JSON output parsers per provider
+  - `parsers.py` — JSON output parsers per provider (returns `ParsedOutput`)
   - `parallel.py` — `run_parallel_with_limit()` concurrency helper
   - `llm_pricing.py` — LLM cost calculation via LiteLLM pricing data with disk cache
   - `ai_models.py` — `AIModelCache` for model listing and validation per provider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,9 @@ Shared async Python package for calling AI CLI tools (Claude, Gemini, Cursor) vi
 ## Project Structure
 - `src/ai_cli_runner/` — package source
   - `client.py` — main `call_ai_cli()` function, subprocess management
-  - `models.py` — `AIResult` (with `thinking` field for chain-of-thought), `AITokenUsage`, `ParsedOutput` dataclasses
+  - `models.py` — `AIResult` (with `thinking` field for chain-of-thought), `AITokenUsage` dataclasses
   - `providers.py` — provider configs (claude, gemini, cursor)
-  - `parsers.py` — JSON output parsers per provider (returns `ParsedOutput`)
+  - `parsers.py` — JSON output parsers per provider
   - `parallel.py` — `run_parallel_with_limit()` concurrency helper
   - `llm_pricing.py` — LLM cost calculation via LiteLLM pricing data with disk cache
   - `ai_models.py` — `AIModelCache` for model listing and validation per provider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Shared async Python package for calling AI CLI tools (Claude, Gemini, Cursor) vi
 ## Project Structure
 - `src/ai_cli_runner/` — package source
   - `client.py` — main `call_ai_cli()` function, subprocess management
-  - `models.py` — `AIResult`, `AITokenUsage` dataclasses
+  - `models.py` — `AIResult` (with `thinking` field for chain-of-thought), `AITokenUsage` dataclasses
   - `providers.py` — provider configs (claude, gemini, cursor)
   - `parsers.py` — JSON output parsers per provider
   - `parallel.py` — `run_parallel_with_limit()` concurrency helper

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Send a trivial prompt to verify the CLI is installed and working.
 
 Supports tuple unpacking (`success, text = await call_ai_cli(...)`) and boolean evaluation (`if result: ...`).
 
+### `ParsedOutput`
+
+Returned by `parse_json_output()`. Supports backward-compatible tuple unpacking.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | `str` | Response text (final answer only) |
+| `usage` | `AITokenUsage \| None` | Token usage metadata |
+| `thinking` | `str` | Intermediate reasoning/chain-of-thought (populated for Cursor; empty for Claude/Gemini) |
+
+Supports tuple unpacking (`text, usage = parse_json_output(...)`) and attribute access (`result.thinking`).
+
 ### `AITokenUsage`
 
 | Field | Type | Description |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Send a trivial prompt to verify the CLI is installed and working.
 | `text` | `str` | Response text |
 | `usage` | `AITokenUsage \| None` | Token usage (when `output_format="json"`) |
 | `session_id` | `str \| None` | Session ID for resuming (when `output_format="json"`) |
+| `thinking` | `str` | Intermediate reasoning/chain-of-thought (populated for Cursor; empty for Claude/Gemini) |
 
 Supports tuple unpacking (`success, text = await call_ai_cli(...)`) and boolean evaluation (`if result: ...`).
 

--- a/README.md
+++ b/README.md
@@ -65,18 +65,6 @@ Send a trivial prompt to verify the CLI is installed and working.
 
 Supports tuple unpacking (`success, text = await call_ai_cli(...)`) and boolean evaluation (`if result: ...`).
 
-### `ParsedOutput`
-
-Returned by `parse_json_output()`. Supports backward-compatible tuple unpacking.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `text` | `str` | Response text (final answer only) |
-| `usage` | `AITokenUsage \| None` | Token usage metadata |
-| `thinking` | `str` | Intermediate reasoning/chain-of-thought (populated for Cursor; empty for Claude/Gemini) |
-
-Supports tuple unpacking (`text, usage = parse_json_output(...)`) and attribute access (`result.thinking`).
-
 ### `AITokenUsage`
 
 | Field | Type | Description |

--- a/src/ai_cli_runner/__init__.py
+++ b/src/ai_cli_runner/__init__.py
@@ -1,9 +1,8 @@
 from ai_cli_runner.ai_models import AIModelCache, model_cache
 from ai_cli_runner.client import call_ai_cli, check_ai_cli_available, get_ai_cli_timeout
 from ai_cli_runner.llm_pricing import LLMPricingCache, pricing_cache
-from ai_cli_runner.models import AIResult, AITokenUsage, ParsedOutput
+from ai_cli_runner.models import AIResult, AITokenUsage
 from ai_cli_runner.parallel import run_parallel_with_limit
-from ai_cli_runner.parsers import parse_json_output
 from ai_cli_runner.providers import PROVIDERS, VALID_AI_PROVIDERS, ProviderConfig
 
 __all__ = [
@@ -13,13 +12,11 @@ __all__ = [
     "AIResult",
     "AITokenUsage",
     "LLMPricingCache",
-    "ParsedOutput",
     "ProviderConfig",
     "call_ai_cli",
     "check_ai_cli_available",
     "get_ai_cli_timeout",
     "model_cache",
-    "parse_json_output",
     "pricing_cache",
     "run_parallel_with_limit",
 ]

--- a/src/ai_cli_runner/__init__.py
+++ b/src/ai_cli_runner/__init__.py
@@ -1,7 +1,7 @@
 from ai_cli_runner.ai_models import AIModelCache, model_cache
 from ai_cli_runner.client import call_ai_cli, check_ai_cli_available, get_ai_cli_timeout
 from ai_cli_runner.llm_pricing import LLMPricingCache, pricing_cache
-from ai_cli_runner.models import AIResult, AITokenUsage
+from ai_cli_runner.models import AIResult, AITokenUsage, ParsedOutput
 from ai_cli_runner.parallel import run_parallel_with_limit
 from ai_cli_runner.parsers import parse_json_output
 from ai_cli_runner.providers import PROVIDERS, VALID_AI_PROVIDERS, ProviderConfig
@@ -13,6 +13,7 @@ __all__ = [
     "AIResult",
     "AITokenUsage",
     "LLMPricingCache",
+    "ParsedOutput",
     "ProviderConfig",
     "call_ai_cli",
     "check_ai_cli_available",

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -220,6 +220,20 @@ async def call_ai_cli(
                 output_format,
             )
         wire_format = config.json_wire_format
+
+        # Strip partial-streaming flags — partial assistant deltas would
+        # break parsers that expect complete turns.
+        # Known flags: Cursor --stream-partial-output, Claude --include-partial-messages
+        partial_flags = {"--stream-partial-output", "--include-partial-messages"}
+        found_partial = partial_flags & set(cleaned_flags)
+        if found_partial:
+            for flag in sorted(found_partial):
+                logger.warning(
+                    "Stripping %s from cli_flags — incompatible with structured output parsing",
+                    flag,
+                )
+            cleaned_flags = [f for f in cleaned_flags if f not in partial_flags]
+
         effective_cli_flags = ["--output-format", wire_format, *cleaned_flags]
 
     if continue_session:
@@ -268,17 +282,17 @@ async def call_ai_cli(
     logger.debug("%s CLI response length: %d chars", provider_info, len(result.stdout))
 
     if output_format:
-        text, usage, thinking = parse_json_output(result.stdout, ai_provider)
-        if usage is not None and usage.cost_usd is None:
-            usage.cost_usd = pricing_cache.calculate_cost(
-                provider=usage.provider or ai_provider,
-                model=usage.model or ai_model,
-                input_tokens=usage.input_tokens,
-                output_tokens=usage.output_tokens,
-                cache_read_tokens=usage.cache_read_tokens,
-                cache_write_tokens=usage.cache_write_tokens,
+        parsed = parse_json_output(result.stdout, ai_provider)
+        if parsed.usage is not None and parsed.usage.cost_usd is None:
+            parsed.usage.cost_usd = pricing_cache.calculate_cost(
+                provider=parsed.usage.provider or ai_provider,
+                model=parsed.usage.model or ai_model,
+                input_tokens=parsed.usage.input_tokens,
+                output_tokens=parsed.usage.output_tokens,
+                cache_read_tokens=parsed.usage.cache_read_tokens,
+                cache_write_tokens=parsed.usage.cache_write_tokens,
             )
-        if usage is None:
+        if parsed.usage is None:
             logger.debug(
                 "%s: output_format=%r requested but no usage parsed; raw output length=%d",
                 provider_info,
@@ -286,8 +300,14 @@ async def call_ai_cli(
                 len(result.stdout),
             )
         # Bridge AITokenUsage.session_id (str, defaults "") → AIResult.session_id (str | None)
-        session = usage.session_id if usage else None
-        return AIResult(success=True, text=text, usage=usage, session_id=session or None, thinking=thinking)
+        session = parsed.usage.session_id if parsed.usage else None
+        return AIResult(
+            success=True,
+            text=parsed.text,
+            usage=parsed.usage,
+            session_id=session or None,
+            thinking=parsed.thinking,
+        )
 
     return AIResult(success=True, text=result.stdout)
 

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -3,6 +3,7 @@ import contextlib
 import os
 import signal
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 from typing import Literal
 
@@ -286,17 +287,19 @@ async def call_ai_cli(
     logger.debug("%s CLI response length: %d chars", provider_info, len(result.stdout))
 
     if output_format:
-        parsed = parse_json_output(result.stdout, ai_provider)
-        if parsed.usage is not None and parsed.usage.cost_usd is None:
-            parsed.usage.cost_usd = pricing_cache.calculate_cost(
-                provider=parsed.usage.provider or ai_provider,
-                model=parsed.usage.model or ai_model,
-                input_tokens=parsed.usage.input_tokens,
-                output_tokens=parsed.usage.output_tokens,
-                cache_read_tokens=parsed.usage.cache_read_tokens,
-                cache_write_tokens=parsed.usage.cache_write_tokens,
+        text, usage, thinking = parse_json_output(result.stdout, ai_provider)
+        if usage is not None and usage.cost_usd is None:
+            cost = pricing_cache.calculate_cost(
+                provider=usage.provider or ai_provider,
+                model=usage.model or ai_model,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_read_tokens=usage.cache_read_tokens,
+                cache_write_tokens=usage.cache_write_tokens,
             )
-        if parsed.usage is None:
+            if cost is not None:
+                usage = replace(usage, cost_usd=cost)
+        if usage is None:
             logger.debug(
                 "%s: output_format=%r requested but no usage parsed; raw output length=%d",
                 provider_info,
@@ -304,13 +307,13 @@ async def call_ai_cli(
                 len(result.stdout),
             )
         # Bridge AITokenUsage.session_id (str, defaults "") → AIResult.session_id (str | None)
-        session = parsed.usage.session_id if parsed.usage else None
+        session = usage.session_id if usage else None
         return AIResult(
             success=True,
-            text=parsed.text,
-            usage=parsed.usage,
+            text=text,
+            usage=usage,
             session_id=session or None,
-            thinking=parsed.thinking,
+            thinking=thinking,
         )
 
     return AIResult(success=True, text=result.stdout)

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -219,7 +219,8 @@ async def call_ai_cli(
                 "Caller-supplied --output-format in cli_flags will be overridden by output_format=%r",
                 output_format,
             )
-        effective_cli_flags = ["--output-format", output_format, *cleaned_flags]
+        wire_format = config.json_wire_format
+        effective_cli_flags = ["--output-format", wire_format, *cleaned_flags]
 
     if continue_session:
         effective_cli_flags.extend(config.continue_flags)

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -268,7 +268,7 @@ async def call_ai_cli(
     logger.debug("%s CLI response length: %d chars", provider_info, len(result.stdout))
 
     if output_format:
-        text, usage = parse_json_output(result.stdout, ai_provider)
+        text, usage, thinking = parse_json_output(result.stdout, ai_provider)
         if usage is not None and usage.cost_usd is None:
             usage.cost_usd = pricing_cache.calculate_cost(
                 provider=usage.provider or ai_provider,
@@ -287,7 +287,7 @@ async def call_ai_cli(
             )
         # Bridge AITokenUsage.session_id (str, defaults "") → AIResult.session_id (str | None)
         session = usage.session_id if usage else None
-        return AIResult(success=True, text=text, usage=usage, session_id=session or None)
+        return AIResult(success=True, text=text, usage=usage, session_id=session or None, thinking=thinking)
 
     return AIResult(success=True, text=result.stdout)
 

--- a/src/ai_cli_runner/client.py
+++ b/src/ai_cli_runner/client.py
@@ -232,7 +232,11 @@ async def call_ai_cli(
                     "Stripping %s from cli_flags — incompatible with structured output parsing",
                     flag,
                 )
-            cleaned_flags = [f for f in cleaned_flags if f not in partial_flags]
+            cleaned_flags = [
+                f
+                for f in cleaned_flags
+                if f not in partial_flags and not any(f.startswith(pf + "=") for pf in partial_flags)
+            ]
 
         effective_cli_flags = ["--output-format", wire_format, *cleaned_flags]
 

--- a/src/ai_cli_runner/models.py
+++ b/src/ai_cli_runner/models.py
@@ -23,6 +23,34 @@ class AITokenUsage:
 
 
 @dataclass
+class ParsedOutput:
+    """Parsed output from an AI CLI JSON response.
+
+    Supports tuple unpacking for backward compatibility:
+        text, usage = parse_json_output(...)
+    Also provides thinking field:
+        result = parse_json_output(...)
+        result.thinking  # intermediate reasoning
+    """
+
+    text: str
+    usage: AITokenUsage | None = None
+    thinking: str = ""
+
+    def __iter__(self) -> Iterator[Any]:
+        """Support tuple unpacking: text, usage = parse_json_output(...)"""
+        return iter((self.text, self.usage))
+
+    def __getitem__(self, index: int) -> Any:
+        """Support index access for backward compatibility."""
+        return (self.text, self.usage)[index]
+
+    def __len__(self) -> int:
+        """Support len() for backward compatibility with tuple."""
+        return 2
+
+
+@dataclass
 class AIResult:
     """Result from an AI CLI call.
 

--- a/src/ai_cli_runner/models.py
+++ b/src/ai_cli_runner/models.py
@@ -34,6 +34,7 @@ class AIResult:
     text: str
     usage: AITokenUsage | None = None
     session_id: str | None = None
+    thinking: str = ""
 
     def __iter__(self) -> Iterator[Any]:
         """Support tuple unpacking for backward compatibility.

--- a/src/ai_cli_runner/models.py
+++ b/src/ai_cli_runner/models.py
@@ -23,34 +23,6 @@ class AITokenUsage:
 
 
 @dataclass
-class ParsedOutput:
-    """Parsed output from an AI CLI JSON response.
-
-    Supports tuple unpacking for backward compatibility:
-        text, usage = parse_json_output(...)
-    Also provides thinking field:
-        result = parse_json_output(...)
-        result.thinking  # intermediate reasoning
-    """
-
-    text: str
-    usage: AITokenUsage | None = None
-    thinking: str = ""
-
-    def __iter__(self) -> Iterator[Any]:
-        """Support tuple unpacking: text, usage = parse_json_output(...)"""
-        return iter((self.text, self.usage))
-
-    def __getitem__(self, index: int) -> Any:
-        """Support index access for backward compatibility."""
-        return (self.text, self.usage)[index]
-
-    def __len__(self) -> int:
-        """Support len() for backward compatibility with tuple."""
-        return 2
-
-
-@dataclass
 class AIResult:
     """Result from an AI CLI call.
 

--- a/src/ai_cli_runner/parsers.py
+++ b/src/ai_cli_runner/parsers.py
@@ -79,8 +79,13 @@ def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
 
         if msg_type == "assistant":
             # Extract text from assistant message content blocks
-            content = data.get("message", {}).get("content", [])
-            texts = [block["text"] for block in content if block.get("type") == "text" and block.get("text")]
+            raw_content = data.get("message", {}).get("content", [])
+            content = raw_content if isinstance(raw_content, list) else []
+            texts = [
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text" and block.get("text")
+            ]
             joined = "\n".join(texts)
             last_assistant_had_text = bool(joined)
             if joined:

--- a/src/ai_cli_runner/parsers.py
+++ b/src/ai_cli_runner/parsers.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from simple_logger.logger import get_logger
 
-from ai_cli_runner.models import AITokenUsage, ParsedOutput
+from ai_cli_runner.models import AITokenUsage
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -63,6 +63,7 @@ def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
     all_assistant_texts: list[str] = []
     usage: AITokenUsage | None = None
     result_text = ""
+    last_assistant_had_text = False
 
     for line in raw_output.splitlines():
         line = line.strip()
@@ -81,6 +82,7 @@ def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
             content = data.get("message", {}).get("content", [])
             texts = [block["text"] for block in content if block.get("type") == "text" and block.get("text")]
             joined = "\n".join(texts)
+            last_assistant_had_text = bool(joined)
             if joined:
                 all_assistant_texts.append(joined)
 
@@ -102,12 +104,15 @@ def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
         logger.warning("No result line found in Cursor stream-json output; returning best-effort text")
 
     # Use last assistant message if available, otherwise fall back to result text
-    if all_assistant_texts:
+    if all_assistant_texts and last_assistant_had_text:
         text = all_assistant_texts[-1]
         thinking = "\n\n".join(all_assistant_texts[:-1]) if len(all_assistant_texts) >= 2 else ""
-    else:
+    elif result_text:
         text = result_text
-        thinking = ""
+        thinking = "\n\n".join(all_assistant_texts)
+    else:
+        text = all_assistant_texts[-1] if all_assistant_texts else ""
+        thinking = "\n\n".join(all_assistant_texts[:-1]) if len(all_assistant_texts) >= 2 else ""
     return text, usage, thinking
 
 
@@ -163,27 +168,20 @@ def parse_gemini_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
     return text, usage, ""
 
 
-def parse_json_output(raw_output: str, provider: str) -> ParsedOutput:
+def parse_json_output(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None, str]:
     """Route to the correct provider parser.
 
-    Best-effort: if parsing fails, log warning and return ParsedOutput with raw text.
-
-    Returns:
-        ParsedOutput supporting backward-compatible tuple unpacking:
-            text, usage = parse_json_output(...)   # still works
-            result = parse_json_output(...)         # access .thinking too
+    Best-effort: if parsing fails, log warning and return (raw_output, None, "").
     """
-    # Lazy import to avoid circular dependency (providers imports parsers at module level)
     from ai_cli_runner.providers import PROVIDERS
 
     config = PROVIDERS.get(provider)
     if config is None or config.parse_json is None:
         logger.warning("No JSON parser for provider '%s'; returning raw output", provider)
-        return ParsedOutput(text=raw_output, usage=None, thinking="")
+        return raw_output, None, ""
 
     try:
-        text, usage, thinking = config.parse_json(raw_output, provider)
-        return ParsedOutput(text=text, usage=usage, thinking=thinking)
-    except Exception:  # noqa: BLE001 — best-effort: never raise to caller
+        return config.parse_json(raw_output, provider)
+    except Exception:  # noqa: BLE001
         logger.warning("Failed to parse JSON output from '%s'; returning raw output", provider, exc_info=True)
-        return ParsedOutput(text=raw_output, usage=None, thinking="")
+        return raw_output, None, ""

--- a/src/ai_cli_runner/parsers.py
+++ b/src/ai_cli_runner/parsers.py
@@ -30,8 +30,8 @@ def _extract_json(raw_output: str) -> dict[str, Any]:
         return json.loads(raw_output[start : end + 1])
 
 
-def parse_claude_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
-    """Parse Claude CLI JSON output. Returns (text, usage)."""
+def parse_claude_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None, str]:
+    """Parse Claude CLI JSON output. Returns (text, usage, thinking)."""
     data = _extract_json(raw_output)
     text = data.get("result", "")
 
@@ -50,17 +50,17 @@ def parse_claude_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
         provider=provider,
         session_id=data.get("session_id", ""),
     )
-    return text, usage
+    return text, usage, ""
 
 
-def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
-    """Parse Cursor CLI stream-json output. Returns (text, usage).
+def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None, str]:
+    """Parse Cursor CLI stream-json output. Returns (text, usage, thinking).
 
     Cursor uses stream-json format (NDJSON) to separate intermediate tool-use
     reasoning from the final answer. We extract only the last assistant message
     as the result text, and usage from the final result line.
     """
-    last_assistant_text = ""
+    all_assistant_texts: list[str] = []
     usage: AITokenUsage | None = None
     result_text = ""
 
@@ -71,6 +71,7 @@ def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
         try:
             data = json.loads(line)
         except json.JSONDecodeError:
+            logger.debug("Skipping non-JSON line in Cursor stream: %s", line[:120])
             continue
 
         msg_type = data.get("type", "")
@@ -79,7 +80,9 @@ def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
             # Extract text from assistant message content blocks
             content = data.get("message", {}).get("content", [])
             texts = [block["text"] for block in content if block.get("type") == "text" and block.get("text")]
-            last_assistant_text = "\n".join(texts)
+            joined = "\n".join(texts)
+            if joined:
+                all_assistant_texts.append(joined)
 
         elif msg_type == "result":
             result_text = data.get("result", "")
@@ -99,12 +102,17 @@ def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
         logger.warning("No result line found in Cursor stream-json output; returning best-effort text")
 
     # Use last assistant message if available, otherwise fall back to result text
-    text = last_assistant_text or result_text
-    return text, usage
+    if all_assistant_texts:
+        text = all_assistant_texts[-1]
+        thinking = "\n\n".join(all_assistant_texts[:-1]) if len(all_assistant_texts) >= 2 else ""
+    else:
+        text = result_text
+        thinking = ""
+    return text, usage, thinking
 
 
-def parse_gemini_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
-    """Parse Gemini CLI JSON output. Returns (text, usage).
+def parse_gemini_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None, str]:
+    """Parse Gemini CLI JSON output. Returns (text, usage, thinking).
 
     Note: text field is 'response' not 'result'.
     Note: Gemini may use multiple models (e.g., router + main); tokens and
@@ -152,13 +160,13 @@ def parse_gemini_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
         provider=provider,
         session_id=data.get("session_id", ""),
     )
-    return text, usage
+    return text, usage, ""
 
 
-def parse_json_output(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
+def parse_json_output(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None, str]:
     """Route to the correct provider parser.
 
-    Best-effort: if parsing fails, log warning and return (raw_output, None).
+    Best-effort: if parsing fails, log warning and return (raw_output, None, "").
     """
     # Lazy import to avoid circular dependency (providers imports parsers at module level)
     from ai_cli_runner.providers import PROVIDERS
@@ -166,10 +174,10 @@ def parse_json_output(raw_output: str, provider: str) -> tuple[str, AITokenUsage
     config = PROVIDERS.get(provider)
     if config is None or config.parse_json is None:
         logger.warning("No JSON parser for provider '%s'; returning raw output", provider)
-        return raw_output, None
+        return raw_output, None, ""
 
     try:
         return config.parse_json(raw_output, provider)
     except Exception:  # noqa: BLE001 — best-effort: never raise to caller
         logger.warning("Failed to parse JSON output from '%s'; returning raw output", provider, exc_info=True)
-        return raw_output, None
+        return raw_output, None, ""

--- a/src/ai_cli_runner/parsers.py
+++ b/src/ai_cli_runner/parsers.py
@@ -54,21 +54,52 @@ def parse_claude_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
 
 
 def parse_cursor_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None]:
-    """Parse Cursor CLI JSON output. Returns (text, usage)."""
-    data = _extract_json(raw_output)
-    text = data.get("result", "")
+    """Parse Cursor CLI stream-json output. Returns (text, usage).
 
-    usage_data = data.get("usage", {})
+    Cursor uses stream-json format (NDJSON) to separate intermediate tool-use
+    reasoning from the final answer. We extract only the last assistant message
+    as the result text, and usage from the final result line.
+    """
+    last_assistant_text = ""
+    usage: AITokenUsage | None = None
+    result_text = ""
 
-    usage = AITokenUsage(
-        input_tokens=usage_data.get("inputTokens", 0),
-        output_tokens=usage_data.get("outputTokens", 0),
-        cache_read_tokens=usage_data.get("cacheReadTokens", 0),
-        cache_write_tokens=usage_data.get("cacheWriteTokens", 0),
-        duration_ms=data.get("duration_ms"),
-        provider=provider,
-        session_id=data.get("session_id", ""),
-    )
+    for line in raw_output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        msg_type = data.get("type", "")
+
+        if msg_type == "assistant":
+            # Extract text from assistant message content blocks
+            content = data.get("message", {}).get("content", [])
+            texts = [block["text"] for block in content if block.get("type") == "text" and block.get("text")]
+            last_assistant_text = "\n".join(texts)
+
+        elif msg_type == "result":
+            result_text = data.get("result", "")
+            # Extract usage from the result line
+            usage_data = data.get("usage", {})
+            usage = AITokenUsage(
+                input_tokens=usage_data.get("inputTokens", 0),
+                output_tokens=usage_data.get("outputTokens", 0),
+                cache_read_tokens=usage_data.get("cacheReadTokens", 0),
+                cache_write_tokens=usage_data.get("cacheWriteTokens", 0),
+                duration_ms=data.get("duration_ms"),
+                provider=provider,
+                session_id=data.get("session_id", ""),
+            )
+
+    if usage is None:
+        logger.warning("No result line found in Cursor stream-json output; returning best-effort text")
+
+    # Use last assistant message if available, otherwise fall back to result text
+    text = last_assistant_text or result_text
     return text, usage
 
 

--- a/src/ai_cli_runner/parsers.py
+++ b/src/ai_cli_runner/parsers.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from simple_logger.logger import get_logger
 
-from ai_cli_runner.models import AITokenUsage
+from ai_cli_runner.models import AITokenUsage, ParsedOutput
 
 logger = get_logger(name=__name__, level=os.environ.get("LOG_LEVEL", "INFO"))
 
@@ -163,10 +163,15 @@ def parse_gemini_json(raw_output: str, provider: str) -> tuple[str, AITokenUsage
     return text, usage, ""
 
 
-def parse_json_output(raw_output: str, provider: str) -> tuple[str, AITokenUsage | None, str]:
+def parse_json_output(raw_output: str, provider: str) -> ParsedOutput:
     """Route to the correct provider parser.
 
-    Best-effort: if parsing fails, log warning and return (raw_output, None, "").
+    Best-effort: if parsing fails, log warning and return ParsedOutput with raw text.
+
+    Returns:
+        ParsedOutput supporting backward-compatible tuple unpacking:
+            text, usage = parse_json_output(...)   # still works
+            result = parse_json_output(...)         # access .thinking too
     """
     # Lazy import to avoid circular dependency (providers imports parsers at module level)
     from ai_cli_runner.providers import PROVIDERS
@@ -174,10 +179,11 @@ def parse_json_output(raw_output: str, provider: str) -> tuple[str, AITokenUsage
     config = PROVIDERS.get(provider)
     if config is None or config.parse_json is None:
         logger.warning("No JSON parser for provider '%s'; returning raw output", provider)
-        return raw_output, None, ""
+        return ParsedOutput(text=raw_output, usage=None, thinking="")
 
     try:
-        return config.parse_json(raw_output, provider)
+        text, usage, thinking = config.parse_json(raw_output, provider)
+        return ParsedOutput(text=text, usage=usage, thinking=thinking)
     except Exception:  # noqa: BLE001 — best-effort: never raise to caller
         logger.warning("Failed to parse JSON output from '%s'; returning raw output", provider, exc_info=True)
-        return raw_output, None, ""
+        return ParsedOutput(text=raw_output, usage=None, thinking="")

--- a/src/ai_cli_runner/providers.py
+++ b/src/ai_cli_runner/providers.py
@@ -18,7 +18,7 @@ class ProviderConfig:
 
     binary: str
     build_cmd: Callable[[str, str, Path | None, list[str]], list[str]]
-    parse_json: Callable[[str, str], tuple[str, AITokenUsage | None]] | None = None
+    parse_json: Callable[[str, str], tuple[str, AITokenUsage | None, str]] | None = None
     continue_flags: tuple[str, ...] = ()
     resume_flag: str = ""
     json_wire_format: str = "json"  # actual --output-format value sent to CLI

--- a/src/ai_cli_runner/providers.py
+++ b/src/ai_cli_runner/providers.py
@@ -21,6 +21,7 @@ class ProviderConfig:
     parse_json: Callable[[str, str], tuple[str, AITokenUsage | None]] | None = None
     continue_flags: tuple[str, ...] = ()
     resume_flag: str = ""
+    json_wire_format: str = "json"  # actual --output-format value sent to CLI
 
 
 def _build_claude_cmd(binary: str, model: str, _cwd: Path | None, cli_flags: list[str]) -> list[str]:
@@ -62,6 +63,7 @@ PROVIDERS: dict[str, ProviderConfig] = {
         parse_json=parse_cursor_json,
         continue_flags=("--continue",),
         resume_flag="--resume",
+        json_wire_format="stream-json",
     ),
 }
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -287,6 +287,79 @@ class TestCallAiCli:
         assert result.success is True
         assert result.text == "Hello!"
 
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_cursor_strips_partial_streaming_flag(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        """Cursor strips --stream-partial-output when output_format='json'."""
+        import json
+
+        cursor_response = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
+                        "session_id": "s1",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "is_error": False,
+                        "duration_ms": 100,
+                        "result": "Hello!",
+                        "session_id": "s1",
+                        "usage": {
+                            "inputTokens": 5,
+                            "outputTokens": 3,
+                            "cacheReadTokens": 0,
+                            "cacheWriteTokens": 0,
+                        },
+                    }
+                ),
+            ]
+        )
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=cursor_response, stderr="")
+        await call_ai_cli(
+            prompt="test",
+            ai_provider="cursor",
+            ai_model="test-model",
+            output_format="json",
+            cli_flags=["--stream-partial-output", "--force"],
+        )
+        cmd = mock_run.call_args[0][0]
+        assert "--stream-partial-output" not in cmd
+        assert "--force" in cmd
+
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_claude_strips_partial_streaming_flag(self, mock_run: MagicMock, _mock_thread: MagicMock) -> None:
+        """Claude strips --include-partial-messages when output_format='json'."""
+        import json
+
+        claude_response = json.dumps(
+            {
+                "type": "result",
+                "result": "Hello!",
+                "duration_ms": 100,
+                "total_cost_usd": 0.01,
+                "usage": {"input_tokens": 5, "output_tokens": 3},
+                "modelUsage": {"opus-4": {}},
+            }
+        )
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=claude_response, stderr="")
+        await call_ai_cli(
+            prompt="test",
+            ai_provider="claude",
+            ai_model="opus-4",
+            output_format="json",
+            cli_flags=["--include-partial-messages", "--force"],
+        )
+        cmd = mock_run.call_args[0][0]
+        assert "--include-partial-messages" not in cmd
+        assert "--force" in cmd
+
     async def test_error_returns_ai_result(self) -> None:
         result = await call_ai_cli(prompt="hello", ai_provider="unknown", ai_model="model")
         assert isinstance(result, AIResult)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -250,6 +250,43 @@ class TestCallAiCli:
             "--dangerously-skip-permissions",
         ]
 
+    @patch("ai_cli_runner.client.asyncio.to_thread", side_effect=fake_to_thread)
+    @patch("ai_cli_runner.client._run_with_process_group")
+    async def test_cursor_output_format_uses_stream_json_wire_format(
+        self, mock_run: MagicMock, _mock_thread: MagicMock
+    ) -> None:
+        import json
+
+        cursor_response = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
+                        "session_id": "s1",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "is_error": False,
+                        "duration_ms": 100,
+                        "result": "Hello!",
+                        "session_id": "s1",
+                        "usage": {"inputTokens": 5, "outputTokens": 3, "cacheReadTokens": 0, "cacheWriteTokens": 0},
+                    }
+                ),
+            ]
+        )
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=cursor_response, stderr="")
+        result = await call_ai_cli(prompt="hello", ai_provider="cursor", ai_model="gpt-4", output_format="json")
+        cmd = mock_run.call_args[0][0]
+        idx = cmd.index("--output-format")
+        assert cmd[idx + 1] == "stream-json"  # cursor uses stream-json on the wire
+        assert result.success is True
+        assert result.text == "Hello!"
+
     async def test_error_returns_ai_result(self) -> None:
         result = await call_ai_cli(prompt="hello", ai_provider="unknown", ai_model="model")
         assert isinstance(result, AIResult)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ai_cli_runner.models import AIResult, AITokenUsage
+from ai_cli_runner.models import AIResult, AITokenUsage, ParsedOutput
 
 
 class TestAITokenUsage:
@@ -42,6 +42,56 @@ class TestAITokenUsage:
     def test_session_id_custom(self) -> None:
         usage = AITokenUsage(session_id="sess-abc-123")
         assert usage.session_id == "sess-abc-123"
+
+
+class TestParsedOutput:
+    def test_default_thinking(self) -> None:
+        parsed = ParsedOutput(text="hello")
+        assert parsed.thinking == ""
+
+    def test_default_usage(self) -> None:
+        parsed = ParsedOutput(text="hello")
+        assert parsed.usage is None
+
+    def test_tuple_unpacking(self) -> None:
+        usage = AITokenUsage(input_tokens=10)
+        parsed = ParsedOutput(text="hello", usage=usage, thinking="reasoning")
+        text, u = parsed
+        assert text == "hello"
+        assert u is usage
+
+    def test_tuple_unpacking_no_usage(self) -> None:
+        parsed = ParsedOutput(text="hello")
+        text, usage = parsed
+        assert text == "hello"
+        assert usage is None
+
+    def test_thinking_accessible(self) -> None:
+        parsed = ParsedOutput(text="answer", thinking="intermediate")
+        assert parsed.thinking == "intermediate"
+
+    def test_thinking_not_in_tuple_unpacking(self) -> None:
+        parsed = ParsedOutput(text="answer", thinking="intermediate")
+        text, usage = parsed
+        assert text == "answer"
+        assert usage is None
+        # thinking is still accessible via attribute
+        assert parsed.thinking == "intermediate"
+
+    def test_len(self) -> None:
+        parsed = ParsedOutput(text="hello", thinking="some thinking")
+        assert len(parsed) == 2
+
+    def test_index_access(self) -> None:
+        usage = AITokenUsage(output_tokens=5)
+        parsed = ParsedOutput(text="hello", usage=usage)
+        assert parsed[0] == "hello"
+        assert parsed[1] is usage
+
+    def test_index_out_of_range(self) -> None:
+        parsed = ParsedOutput(text="hello")
+        with pytest.raises(IndexError):
+            parsed[2]
 
 
 class TestAIResult:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ai_cli_runner.models import AIResult, AITokenUsage
 
 
@@ -107,3 +109,30 @@ class TestAIResult:
         assert text == "hi"
         # session_id is still accessible via attribute
         assert result.session_id == "sess-xyz"
+
+    def test_thinking_default_empty(self) -> None:
+        result = AIResult(success=True, text="hi")
+        assert result.thinking == ""
+
+    def test_thinking_custom_value(self) -> None:
+        result = AIResult(success=True, text="answer", thinking="intermediate reasoning")
+        assert result.thinking == "intermediate reasoning"
+
+    def test_thinking_not_in_tuple_unpacking(self) -> None:
+        result = AIResult(success=True, text="hi", thinking="some thinking")
+        success, text = result
+        assert success is True
+        assert text == "hi"
+        # thinking is still accessible via attribute
+        assert result.thinking == "some thinking"
+
+    def test_thinking_not_in_getitem(self) -> None:
+        result = AIResult(success=True, text="hi", thinking="some thinking")
+        assert result[0] is True
+        assert result[1] == "hi"
+        with pytest.raises(IndexError):
+            result[2]
+
+    def test_thinking_not_in_len(self) -> None:
+        result = AIResult(success=True, text="hi", thinking="some thinking")
+        assert len(result) == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ai_cli_runner.models import AIResult, AITokenUsage, ParsedOutput
+from ai_cli_runner.models import AIResult, AITokenUsage
 
 
 class TestAITokenUsage:
@@ -42,56 +42,6 @@ class TestAITokenUsage:
     def test_session_id_custom(self) -> None:
         usage = AITokenUsage(session_id="sess-abc-123")
         assert usage.session_id == "sess-abc-123"
-
-
-class TestParsedOutput:
-    def test_default_thinking(self) -> None:
-        parsed = ParsedOutput(text="hello")
-        assert parsed.thinking == ""
-
-    def test_default_usage(self) -> None:
-        parsed = ParsedOutput(text="hello")
-        assert parsed.usage is None
-
-    def test_tuple_unpacking(self) -> None:
-        usage = AITokenUsage(input_tokens=10)
-        parsed = ParsedOutput(text="hello", usage=usage, thinking="reasoning")
-        text, u = parsed
-        assert text == "hello"
-        assert u is usage
-
-    def test_tuple_unpacking_no_usage(self) -> None:
-        parsed = ParsedOutput(text="hello")
-        text, usage = parsed
-        assert text == "hello"
-        assert usage is None
-
-    def test_thinking_accessible(self) -> None:
-        parsed = ParsedOutput(text="answer", thinking="intermediate")
-        assert parsed.thinking == "intermediate"
-
-    def test_thinking_not_in_tuple_unpacking(self) -> None:
-        parsed = ParsedOutput(text="answer", thinking="intermediate")
-        text, usage = parsed
-        assert text == "answer"
-        assert usage is None
-        # thinking is still accessible via attribute
-        assert parsed.thinking == "intermediate"
-
-    def test_len(self) -> None:
-        parsed = ParsedOutput(text="hello", thinking="some thinking")
-        assert len(parsed) == 2
-
-    def test_index_access(self) -> None:
-        usage = AITokenUsage(output_tokens=5)
-        parsed = ParsedOutput(text="hello", usage=usage)
-        assert parsed[0] == "hello"
-        assert parsed[1] is usage
-
-    def test_index_out_of_range(self) -> None:
-        parsed = ParsedOutput(text="hello")
-        with pytest.raises(IndexError):
-            parsed[2]
 
 
 class TestAIResult:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -313,7 +313,7 @@ class TestParseCursorJson:
         assert usage.output_tokens == 10
         assert usage.duration_ms == 2000
 
-    def test_last_assistant_no_text_blocks_uses_previous_assistant(self) -> None:
+    def test_last_assistant_no_text_blocks_uses_result_fallback(self) -> None:
         """If last assistant message has no text blocks, fall back to result text."""
         assistant_1 = {
             "type": "assistant",
@@ -352,11 +352,10 @@ class TestParseCursorJson:
             json.dumps(result_line),
         ]
         text, usage, thinking = parse_cursor_json("\n".join(lines), "cursor")
-        # assistant_1 has text, assistant_2 has no text blocks (only tool_use, not appended)
-        # So all_assistant_texts = ["Intermediate reasoning"], text = that, thinking = ""
-        assert text == "Intermediate reasoning"
+        # assistant_2 had no text, so last_assistant_had_text=False → fall back to result_text
+        assert text == "Final answer from result"
         assert usage is not None
-        assert thinking == ""
+        assert thinking == "Intermediate reasoning"
 
     def test_malformed_ndjson_lines_skipped(self) -> None:
         """Non-JSON lines in stream output are silently skipped."""
@@ -524,62 +523,46 @@ class TestParseGeminiJson:
 
 class TestParseJsonOutput:
     def test_routes_to_claude(self) -> None:
-        result = parse_json_output(CLAUDE_JSON, "claude")
-        assert result.text == "\n\nHi!"
-        assert result.usage is not None
-        assert result.usage.provider == "claude"
-
-    def test_routes_to_cursor(self) -> None:
-        result = parse_json_output(CURSOR_JSON, "cursor")
-        assert result.text == "Hi — good to meet you. How can I help you today?"
-        assert result.usage is not None
-        assert result.usage.provider == "cursor"
-
-    def test_routes_to_gemini(self) -> None:
-        result = parse_json_output(GEMINI_JSON_BODY, "gemini")
-        assert result.text == "Hi!"
-        assert result.usage is not None
-        assert result.usage.provider == "gemini"
-
-    def test_unknown_provider_returns_raw(self) -> None:
-        result = parse_json_output("raw output", "unknown_provider")
-        assert result.text == "raw output"
-        assert result.usage is None
-        assert result.thinking == ""
-
-    def test_invalid_json_returns_raw(self) -> None:
-        result = parse_json_output("not json at all", "claude")
-        assert result.text == "not json at all"
-        assert result.usage is None
-        assert result.thinking == ""
-
-    def test_best_effort_no_exception(self) -> None:
-        # Should never raise, even with garbage input
-        result = parse_json_output("", "gemini")
-        assert result.text == ""
-        assert result.usage is None
-        assert result.thinking == ""
-
-    def test_backward_compat_tuple_unpacking(self) -> None:
-        """2-tuple unpacking still works for backward compatibility."""
-        text, usage = parse_json_output(CLAUDE_JSON, "claude")
+        text, usage, _thinking = parse_json_output(CLAUDE_JSON, "claude")
         assert text == "\n\nHi!"
         assert usage is not None
         assert usage.provider == "claude"
 
-    def test_backward_compat_tuple_unpacking_cursor(self) -> None:
-        """2-tuple unpacking works with cursor and thinking is accessible."""
-        result = parse_json_output(CURSOR_JSON, "cursor")
-        text, usage = result  # 2-tuple unpacking still works
+    def test_routes_to_cursor(self) -> None:
+        text, usage, _thinking = parse_json_output(CURSOR_JSON, "cursor")
         assert text == "Hi — good to meet you. How can I help you today?"
         assert usage is not None
-        assert result.thinking == "Let me check that for you."
+        assert usage.provider == "cursor"
 
-    def test_thinking_accessible_on_result(self) -> None:
-        """Thinking field is accessible on the ParsedOutput object."""
-        result = parse_json_output(CURSOR_JSON, "cursor")
-        assert result.thinking == "Let me check that for you."
+    def test_routes_to_gemini(self) -> None:
+        text, usage, _thinking = parse_json_output(GEMINI_JSON_BODY, "gemini")
+        assert text == "Hi!"
+        assert usage is not None
+        assert usage.provider == "gemini"
+
+    def test_unknown_provider_returns_raw(self) -> None:
+        text, usage, thinking = parse_json_output("raw output", "unknown_provider")
+        assert text == "raw output"
+        assert usage is None
+        assert thinking == ""
+
+    def test_invalid_json_returns_raw(self) -> None:
+        text, usage, thinking = parse_json_output("not json at all", "claude")
+        assert text == "not json at all"
+        assert usage is None
+        assert thinking == ""
+
+    def test_best_effort_no_exception(self) -> None:
+        # Should never raise, even with garbage input
+        text, usage, thinking = parse_json_output("", "gemini")
+        assert text == ""
+        assert usage is None
+        assert thinking == ""
+
+    def test_thinking_for_cursor(self) -> None:
+        _text, _usage, thinking = parse_json_output(CURSOR_JSON, "cursor")
+        assert thinking == "Let me check that for you."
 
     def test_thinking_empty_for_claude(self) -> None:
-        result = parse_json_output(CLAUDE_JSON, "claude")
-        assert result.thinking == ""
+        _text, _usage, thinking = parse_json_output(CLAUDE_JSON, "claude")
+        assert thinking == ""

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -524,38 +524,63 @@ class TestParseGeminiJson:
 
 class TestParseJsonOutput:
     def test_routes_to_claude(self) -> None:
-        text, usage, _thinking = parse_json_output(CLAUDE_JSON, "claude")
+        result = parse_json_output(CLAUDE_JSON, "claude")
+        assert result.text == "\n\nHi!"
+        assert result.usage is not None
+        assert result.usage.provider == "claude"
+
+    def test_routes_to_cursor(self) -> None:
+        result = parse_json_output(CURSOR_JSON, "cursor")
+        assert result.text == "Hi — good to meet you. How can I help you today?"
+        assert result.usage is not None
+        assert result.usage.provider == "cursor"
+
+    def test_routes_to_gemini(self) -> None:
+        result = parse_json_output(GEMINI_JSON_BODY, "gemini")
+        assert result.text == "Hi!"
+        assert result.usage is not None
+        assert result.usage.provider == "gemini"
+
+    def test_unknown_provider_returns_raw(self) -> None:
+        result = parse_json_output("raw output", "unknown_provider")
+        assert result.text == "raw output"
+        assert result.usage is None
+        assert result.thinking == ""
+
+    def test_invalid_json_returns_raw(self) -> None:
+        result = parse_json_output("not json at all", "claude")
+        assert result.text == "not json at all"
+        assert result.usage is None
+        assert result.thinking == ""
+
+    def test_best_effort_no_exception(self) -> None:
+        # Should never raise, even with garbage input
+        result = parse_json_output("", "gemini")
+        assert result.text == ""
+        assert result.usage is None
+        assert result.thinking == ""
+
+    def test_backward_compat_tuple_unpacking(self) -> None:
+        """2-tuple unpacking still works for backward compatibility."""
+        text, usage = parse_json_output(CLAUDE_JSON, "claude")
         assert text == "\n\nHi!"
         assert usage is not None
         assert usage.provider == "claude"
 
-    def test_routes_to_cursor(self) -> None:
-        text, usage, _thinking = parse_json_output(CURSOR_JSON, "cursor")
+    def test_backward_compat_tuple_unpacking_cursor(self) -> None:
+        """2-tuple unpacking works with cursor and thinking is accessible."""
+        text, usage = parse_json_output(CURSOR_JSON, "cursor")
         assert text == "Hi — good to meet you. How can I help you today?"
         assert usage is not None
-        assert usage.provider == "cursor"
+        # thinking is accessible via object
+        result = parse_json_output(CURSOR_JSON, "cursor")
+        assert result.thinking == "Let me check that for you."
 
-    def test_routes_to_gemini(self) -> None:
-        text, usage, _thinking = parse_json_output(GEMINI_JSON_BODY, "gemini")
-        assert text == "Hi!"
-        assert usage is not None
-        assert usage.provider == "gemini"
+    def test_thinking_accessible_on_result(self) -> None:
+        """Thinking field is accessible on the ParsedOutput object."""
+        result = parse_json_output(CURSOR_JSON, "cursor")
+        assert result.thinking == "Let me check that for you."
 
-    def test_unknown_provider_returns_raw(self) -> None:
-        text, usage, thinking = parse_json_output("raw output", "unknown_provider")
-        assert text == "raw output"
-        assert usage is None
-        assert thinking == ""
-
-    def test_invalid_json_returns_raw(self) -> None:
-        text, usage, thinking = parse_json_output("not json at all", "claude")
-        assert text == "not json at all"
-        assert usage is None
-        assert thinking == ""
-
-    def test_best_effort_no_exception(self) -> None:
-        # Should never raise, even with garbage input
-        text, usage, thinking = parse_json_output("", "gemini")
-        assert text == ""
-        assert usage is None
-        assert thinking == ""
+    def test_thinking_empty_for_claude(self) -> None:
+        result = parse_json_output(CLAUDE_JSON, "claude")
+        assert result.thinking == ""

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -303,6 +303,27 @@ class TestParseCursorJson:
         assert "Let me check" not in text
         assert text == "Hi — good to meet you. How can I help you today?"
 
+    def test_assistant_content_shape_mismatch_does_not_crash(self) -> None:
+        """Parser handles unexpected content shapes without crashing."""
+        lines = [
+            json.dumps({"type": "assistant", "message": {"role": "assistant", "content": {"type": "text"}}}),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "duration_ms": 50,
+                    "result": "Final",
+                    "session_id": "m2",
+                    "usage": {"inputTokens": 1, "outputTokens": 1, "cacheReadTokens": 0, "cacheWriteTokens": 0},
+                }
+            ),
+        ]
+        text, usage, thinking = parse_cursor_json("\n".join(lines), "cursor")
+        assert text == "Final"
+        assert usage is not None
+        assert thinking == ""
+
     def test_simple_single_message(self) -> None:
         """Test with a single assistant message (no tool use)."""
         text, usage, _thinking = parse_cursor_json(CURSOR_SIMPLE_JSON, "cursor")

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -44,23 +44,71 @@ CLAUDE_JSON = json.dumps(
     }
 )
 
-CURSOR_JSON = json.dumps(
-    {
-        "type": "result",
-        "subtype": "success",
-        "is_error": False,
-        "duration_ms": 6661,
-        "duration_api_ms": 6661,
-        "result": "Hi — good to meet you. How can I help you today?",
-        "session_id": "abc123",
-        "usage": {
-            "inputTokens": 3602,
-            "outputTokens": 61,
-            "cacheReadTokens": 9728,
-            "cacheWriteTokens": 0,
-        },
-    }
-)
+# Cursor stream-json (NDJSON) output: multiple lines including chain-of-thought
+_CURSOR_STREAM_LINES = [
+    json.dumps({"type": "system", "subtype": "init", "session_id": "abc123"}),
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "Let me check that for you."}]},
+            "session_id": "abc123",
+        }
+    ),
+    json.dumps({"type": "tool_call", "subtype": "started", "call_id": "call_1"}),
+    json.dumps({"type": "tool_call", "subtype": "completed", "call_id": "call_1"}),
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hi — good to meet you. How can I help you today?"}],
+            },
+            "session_id": "abc123",
+        }
+    ),
+    json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "duration_ms": 6661,
+            "duration_api_ms": 6661,
+            "result": "Let me check that for you.Hi — good to meet you. How can I help you today?",
+            "session_id": "abc123",
+            "usage": {
+                "inputTokens": 3602,
+                "outputTokens": 61,
+                "cacheReadTokens": 9728,
+                "cacheWriteTokens": 0,
+            },
+        }
+    ),
+]
+CURSOR_JSON = "\n".join(_CURSOR_STREAM_LINES)
+
+# Simple cursor output: single assistant message, no tool calls
+_CURSOR_SIMPLE_LINES = [
+    json.dumps({"type": "system", "subtype": "init", "session_id": "simple123"}),
+    json.dumps(
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "Hi there!"}]},
+            "session_id": "simple123",
+        }
+    ),
+    json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "duration_ms": 2000,
+            "result": "Hi there!",
+            "session_id": "simple123",
+            "usage": {"inputTokens": 100, "outputTokens": 10, "cacheReadTokens": 0, "cacheWriteTokens": 0},
+        }
+    ),
+]
+CURSOR_SIMPLE_JSON = "\n".join(_CURSOR_SIMPLE_LINES)
 
 GEMINI_JSON_BODY = json.dumps(
     {
@@ -234,6 +282,118 @@ class TestParseCursorJson:
         _, usage = parsed
         assert usage is not None
         assert usage.session_id == "abc123"
+
+    def test_strips_chain_of_thought(self) -> None:
+        """Verify chain-of-thought from intermediate assistant messages is excluded."""
+        text, _usage = parse_cursor_json(CURSOR_JSON, "cursor")
+        assert "Let me check" not in text
+        assert text == "Hi — good to meet you. How can I help you today?"
+
+    def test_simple_single_message(self) -> None:
+        """Test with a single assistant message (no tool use)."""
+        text, usage = parse_cursor_json(CURSOR_SIMPLE_JSON, "cursor")
+        assert text == "Hi there!"
+        assert usage is not None
+        assert usage.session_id == "simple123"
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 10
+        assert usage.duration_ms == 2000
+
+    def test_last_assistant_empty_content_uses_result_fallback(self) -> None:
+        """If last assistant message has no text blocks, fall back to result text."""
+        assistant_1 = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Intermediate reasoning"}],
+            },
+            "session_id": "x",
+        }
+        assistant_2 = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "t1"}],
+            },
+            "session_id": "x",
+        }
+        result_line = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "duration_ms": 100,
+            "result": "Final answer from result",
+            "session_id": "x",
+            "usage": {
+                "inputTokens": 10,
+                "outputTokens": 5,
+                "cacheReadTokens": 0,
+                "cacheWriteTokens": 0,
+            },
+        }
+        lines = [
+            json.dumps(assistant_1),
+            json.dumps({"type": "tool_call", "subtype": "started", "call_id": "c1"}),
+            json.dumps(assistant_2),
+            json.dumps(result_line),
+        ]
+        text, usage = parse_cursor_json("\n".join(lines), "cursor")
+        # Last assistant had no text blocks, so last_assistant_text is "", falls back to result_text
+        assert text == "Final answer from result"
+        assert usage is not None
+
+    def test_malformed_ndjson_lines_skipped(self) -> None:
+        """Non-JSON lines in stream output are silently skipped."""
+        assistant_msg = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hello!"}],
+            },
+            "session_id": "m1",
+        }
+        result_line = {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "duration_ms": 100,
+            "result": "Hello!",
+            "session_id": "m1",
+            "usage": {
+                "inputTokens": 10,
+                "outputTokens": 5,
+                "cacheReadTokens": 0,
+                "cacheWriteTokens": 0,
+            },
+        }
+        lines = [
+            "Warning: some CLI noise",
+            "not json at all",
+            json.dumps(assistant_msg),
+            json.dumps(result_line),
+        ]
+        text, usage = parse_cursor_json("\n".join(lines), "cursor")
+        assert text == "Hello!"
+        assert usage is not None
+        assert usage.session_id == "m1"
+
+    def test_no_result_line_returns_empty(self) -> None:
+        """If stream has no result line, return best-effort text with None usage."""
+        assistant_msg = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Partial response"}],
+            },
+            "session_id": "nr1",
+        }
+        lines = [
+            json.dumps({"type": "system", "subtype": "init", "session_id": "nr1"}),
+            json.dumps(assistant_msg),
+        ]
+        text, usage = parse_cursor_json("\n".join(lines), "cursor")
+        assert text == "Partial response"
+        assert usage is None
 
 
 class TestParseGeminiJson:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -176,122 +176,136 @@ class TestExtractJson:
 
 class TestParseClaudeJson:
     @pytest.fixture()
-    def parsed(self) -> tuple[str, AITokenUsage | None]:
+    def parsed(self) -> tuple[str, AITokenUsage | None, str]:
         return parse_claude_json(CLAUDE_JSON, "claude")
 
-    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        text, _usage = parsed
+    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        text, _usage, _thinking = parsed
         assert text == "\n\nHi!"
 
-    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.input_tokens == 3
 
-    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.output_tokens == 6
 
-    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.cache_read_tokens == 11925
 
-    def test_parses_cache_write_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_cache_write_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.cache_write_tokens == 11936
 
-    def test_parses_cost(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_cost(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.cost_usd == 0.0807275
 
-    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.duration_ms == 2647
 
-    def test_parses_model(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_model(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.model == "claude-opus-4-6[1m]"
 
-    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.provider == "claude"
 
-    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.session_id == "sess-claude-123"
+
+    def test_thinking_empty(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, _, thinking = parsed
+        assert thinking == ""
 
 
 class TestParseCursorJson:
     @pytest.fixture()
-    def parsed(self) -> tuple[str, AITokenUsage | None]:
+    def parsed(self) -> tuple[str, AITokenUsage | None, str]:
         return parse_cursor_json(CURSOR_JSON, "cursor")
 
-    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        text, _usage = parsed
+    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        text, _usage, _thinking = parsed
         assert text == "Hi — good to meet you. How can I help you today?"
 
-    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.input_tokens == 3602
 
-    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.output_tokens == 61
 
-    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.cache_read_tokens == 9728
 
-    def test_parses_cache_write_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_cache_write_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.cache_write_tokens == 0
 
-    def test_no_cost(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_no_cost(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.cost_usd is None
 
-    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.duration_ms == 6661
 
-    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.provider == "cursor"
 
-    def test_model_empty_by_design(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_model_empty_by_design(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.model == ""
 
-    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.session_id == "abc123"
 
+    def test_thinking_captures_intermediate_reasoning(self) -> None:
+        """Verify thinking captures intermediate assistant messages."""
+        _, _, thinking = parse_cursor_json(CURSOR_JSON, "cursor")
+        assert thinking == "Let me check that for you."
+
+    def test_thinking_empty_for_single_message(self) -> None:
+        """Verify thinking is empty when there is only one assistant message."""
+        _, _, thinking = parse_cursor_json(CURSOR_SIMPLE_JSON, "cursor")
+        assert thinking == ""
+
     def test_strips_chain_of_thought(self) -> None:
         """Verify chain-of-thought from intermediate assistant messages is excluded."""
-        text, _usage = parse_cursor_json(CURSOR_JSON, "cursor")
+        text, _usage, _thinking = parse_cursor_json(CURSOR_JSON, "cursor")
         assert "Let me check" not in text
         assert text == "Hi — good to meet you. How can I help you today?"
 
     def test_simple_single_message(self) -> None:
         """Test with a single assistant message (no tool use)."""
-        text, usage = parse_cursor_json(CURSOR_SIMPLE_JSON, "cursor")
+        text, usage, _thinking = parse_cursor_json(CURSOR_SIMPLE_JSON, "cursor")
         assert text == "Hi there!"
         assert usage is not None
         assert usage.session_id == "simple123"
@@ -299,7 +313,7 @@ class TestParseCursorJson:
         assert usage.output_tokens == 10
         assert usage.duration_ms == 2000
 
-    def test_last_assistant_empty_content_uses_result_fallback(self) -> None:
+    def test_last_assistant_no_text_blocks_uses_previous_assistant(self) -> None:
         """If last assistant message has no text blocks, fall back to result text."""
         assistant_1 = {
             "type": "assistant",
@@ -337,10 +351,12 @@ class TestParseCursorJson:
             json.dumps(assistant_2),
             json.dumps(result_line),
         ]
-        text, usage = parse_cursor_json("\n".join(lines), "cursor")
-        # Last assistant had no text blocks, so last_assistant_text is "", falls back to result_text
-        assert text == "Final answer from result"
+        text, usage, thinking = parse_cursor_json("\n".join(lines), "cursor")
+        # assistant_1 has text, assistant_2 has no text blocks (only tool_use, not appended)
+        # So all_assistant_texts = ["Intermediate reasoning"], text = that, thinking = ""
+        assert text == "Intermediate reasoning"
         assert usage is not None
+        assert thinking == ""
 
     def test_malformed_ndjson_lines_skipped(self) -> None:
         """Non-JSON lines in stream output are silently skipped."""
@@ -372,7 +388,7 @@ class TestParseCursorJson:
             json.dumps(assistant_msg),
             json.dumps(result_line),
         ]
-        text, usage = parse_cursor_json("\n".join(lines), "cursor")
+        text, usage, _thinking = parse_cursor_json("\n".join(lines), "cursor")
         assert text == "Hello!"
         assert usage is not None
         assert usage.session_id == "m1"
@@ -391,66 +407,66 @@ class TestParseCursorJson:
             json.dumps({"type": "system", "subtype": "init", "session_id": "nr1"}),
             json.dumps(assistant_msg),
         ]
-        text, usage = parse_cursor_json("\n".join(lines), "cursor")
+        text, usage, _thinking = parse_cursor_json("\n".join(lines), "cursor")
         assert text == "Partial response"
         assert usage is None
 
 
 class TestParseGeminiJson:
     @pytest.fixture()
-    def parsed(self) -> tuple[str, AITokenUsage | None]:
+    def parsed(self) -> tuple[str, AITokenUsage | None, str]:
         return parse_gemini_json(GEMINI_JSON_BODY, "gemini")
 
-    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        text, _usage = parsed
+    def test_parses_text(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        text, _usage, _thinking = parsed
         assert text == "Hi!"
 
     def test_parses_text_with_noise(self) -> None:
-        text, _usage = parse_gemini_json(GEMINI_JSON_WITH_NOISE, "gemini")
+        text, _usage, _thinking = parse_gemini_json(GEMINI_JSON_WITH_NOISE, "gemini")
         assert text == "Hi!"
 
-    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_input_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.input_tokens == 10288
 
-    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_output_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.output_tokens == 350
 
-    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_cache_read_tokens(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.cache_read_tokens == 0
 
-    def test_cache_write_tokens_zero(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_cache_write_tokens_zero(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.cache_write_tokens == 0
 
-    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_duration(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.duration_ms == 5371
 
-    def test_parses_model(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_model(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.model == "gemini-3.1-pro-preview"
 
-    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_provider(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.provider == "gemini"
 
-    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None]) -> None:
-        _, usage = parsed
+    def test_parses_session_id(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, usage, _ = parsed
         assert usage is not None
         assert usage.session_id == "sess456"
 
     def test_session_id_with_noise(self) -> None:
-        _, usage = parse_gemini_json(GEMINI_JSON_WITH_NOISE, "gemini")
+        _, usage, _ = parse_gemini_json(GEMINI_JSON_WITH_NOISE, "gemini")
         assert usage is not None
         assert usage.session_id == "sess456"
 
@@ -468,7 +484,7 @@ class TestParseGeminiJson:
                 },
             }
         )
-        _, usage = parse_gemini_json(no_session_json, "gemini")
+        _, usage, _ = parse_gemini_json(no_session_json, "gemini")
         assert usage is not None
         assert usage.session_id == ""
 
@@ -491,7 +507,7 @@ class TestParseGeminiJson:
                 },
             }
         )
-        text, usage = parse_gemini_json(multi_model_json, "gemini")
+        text, usage, _ = parse_gemini_json(multi_model_json, "gemini")
         assert text == "Hello!"
         assert usage is not None
         assert usage.input_tokens == 1197 + 8468  # sum across models
@@ -501,38 +517,45 @@ class TestParseGeminiJson:
         assert usage.model == "gemini-2.5-flash-lite"
         assert usage.provider == "gemini"
 
+    def test_thinking_empty(self, parsed: tuple[str, AITokenUsage | None, str]) -> None:
+        _, _, thinking = parsed
+        assert thinking == ""
+
 
 class TestParseJsonOutput:
     def test_routes_to_claude(self) -> None:
-        text, usage = parse_json_output(CLAUDE_JSON, "claude")
+        text, usage, _thinking = parse_json_output(CLAUDE_JSON, "claude")
         assert text == "\n\nHi!"
         assert usage is not None
         assert usage.provider == "claude"
 
     def test_routes_to_cursor(self) -> None:
-        text, usage = parse_json_output(CURSOR_JSON, "cursor")
+        text, usage, _thinking = parse_json_output(CURSOR_JSON, "cursor")
         assert text == "Hi — good to meet you. How can I help you today?"
         assert usage is not None
         assert usage.provider == "cursor"
 
     def test_routes_to_gemini(self) -> None:
-        text, usage = parse_json_output(GEMINI_JSON_BODY, "gemini")
+        text, usage, _thinking = parse_json_output(GEMINI_JSON_BODY, "gemini")
         assert text == "Hi!"
         assert usage is not None
         assert usage.provider == "gemini"
 
     def test_unknown_provider_returns_raw(self) -> None:
-        text, usage = parse_json_output("raw output", "unknown_provider")
+        text, usage, thinking = parse_json_output("raw output", "unknown_provider")
         assert text == "raw output"
         assert usage is None
+        assert thinking == ""
 
     def test_invalid_json_returns_raw(self) -> None:
-        text, usage = parse_json_output("not json at all", "claude")
+        text, usage, thinking = parse_json_output("not json at all", "claude")
         assert text == "not json at all"
         assert usage is None
+        assert thinking == ""
 
     def test_best_effort_no_exception(self) -> None:
         # Should never raise, even with garbage input
-        text, usage = parse_json_output("", "gemini")
+        text, usage, thinking = parse_json_output("", "gemini")
         assert text == ""
         assert usage is None
+        assert thinking == ""

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -569,11 +569,10 @@ class TestParseJsonOutput:
 
     def test_backward_compat_tuple_unpacking_cursor(self) -> None:
         """2-tuple unpacking works with cursor and thinking is accessible."""
-        text, usage = parse_json_output(CURSOR_JSON, "cursor")
+        result = parse_json_output(CURSOR_JSON, "cursor")
+        text, usage = result  # 2-tuple unpacking still works
         assert text == "Hi — good to meet you. How can I help you today?"
         assert usage is not None
-        # thinking is accessible via object
-        result = parse_json_output(CURSOR_JSON, "cursor")
         assert result.thinking == "Let me check that for you."
 
     def test_thinking_accessible_on_result(self) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -157,3 +157,16 @@ class TestProviderSessionConfig:
         config = ProviderConfig(binary="test", build_cmd=_build_claude_cmd)
         assert config.continue_flags == ()
         assert config.resume_flag == ""
+        assert config.json_wire_format == "json"
+
+    async def test_claude_json_wire_format(self) -> None:
+        config = PROVIDERS["claude"]
+        assert config.json_wire_format == "json"
+
+    async def test_gemini_json_wire_format(self) -> None:
+        config = PROVIDERS["gemini"]
+        assert config.json_wire_format == "json"
+
+    async def test_cursor_json_wire_format(self) -> None:
+        config = PROVIDERS["cursor"]
+        assert config.json_wire_format == "stream-json"


### PR DESCRIPTION
## Summary

Fixes #25 — When using `output_format="json"` with Cursor, the `result` field concatenated all assistant messages (including intermediate reasoning before tool calls) into one string. Claude and Gemini were unaffected.

## Root Cause

Cursor's `--output-format json` naively concatenates all assistant text blocks into the `result` field. Unlike Claude and Gemini (which return only the final answer), Cursor includes intermediate chain-of-thought reasoning like "Running the requested shell command..." before the actual answer.

## Solution

- **Switch Cursor to `stream-json` wire format** internally when user requests `output_format="json"`. The stream-json (NDJSON) format gives individual message objects with turn boundaries, allowing clean separation of intermediate reasoning from the final answer.
- **Add `json_wire_format` field to `ProviderConfig`** — defaults to `"json"`, set to `"stream-json"` for Cursor. Callers still pass `output_format="json"` — the wire detail is hidden.
- **Rewrite `parse_cursor_json`** to parse NDJSON, extracting only the last assistant text block as the clean result.

## Additional Improvements

- **`thinking` field on `AIResult`** — Captures intermediate reasoning (populated for Cursor, empty for Claude/Gemini). Non-breaking: defaults to `""`, excluded from tuple unpacking.
- **`ParsedOutput` dataclass** — New return type for `parse_json_output()` that supports backward-compatible 2-tuple unpacking (`text, usage = parse_json_output(...)`) while also exposing `.thinking`.
- **Partial-streaming flag stripping** — Strips `--stream-partial-output` (Cursor) and `--include-partial-messages` (Claude) from `cli_flags` when `output_format` is set, preventing partial deltas from breaking parsers.

## Breaking Changes

None. All public APIs maintain backward compatibility:
- `call_ai_cli(..., output_format="json")` — unchanged
- `AIResult` — new `thinking` field defaults to `""`, not in tuple unpacking
- `parse_json_output()` — returns `ParsedOutput` (supports `text, usage = ...` unpacking)

## Verified

- All 270 unit tests pass
- Real CLI tests on all 3 providers (Cursor, Claude, Gemini)
- Peer-reviewed by Cursor (gpt-5.4-xhigh-fast) — 3 rounds, all findings resolved
- 3x internal code review (quality, guidelines, security) — all approved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "thinking" field to AI results to surface intermediate reasoning (populated for Cursor; empty for Claude/Gemini)
  * CLI enforces provider-specific on-wire JSON format and removes incompatible partial-streaming flags when using structured JSON output

* **Public API**
  * `ParsedOutput` is now exported

* **Documentation**
  * README and docs updated to document the new field

* **Tests**
  * Added tests for parsing, CLI behavior, and the new field

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/myk-org/ai-cli-runner/pull/26)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->